### PR TITLE
feat: add dashboard API foundation contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The control-plane backend now exposes an initial stable dashboard adapter surfac
 - `GET /api/system/health`
 - `GET /api/system/version`
 - `GET /api/agents`
-- `GET /api/agents/{agentId}`
+- `GET /api/agents/{agent_id}`
 
 These routes are the first step toward the architecture-spec split between
 agent-scoped and system-scoped resources. Legacy Phase 1 routes such as

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ The backend wraps the Hermes CLI and reads from `HERMES_HOME` to provide
 REST endpoints for status, profiles, sessions, skills, cron, logs, and config.
 It does **not** modify Hermes source code.
 
+## Dashboard API contract foundation
+
+The control-plane backend now exposes an initial stable dashboard adapter surface:
+
+- `GET /api/system/health`
+- `GET /api/system/version`
+- `GET /api/agents`
+- `GET /api/agents/{agentId}`
+
+These routes are the first step toward the architecture-spec split between
+agent-scoped and system-scoped resources. Legacy Phase 1 routes such as
+`/api/health` and `/api/profiles` remain available for compatibility while the
+frontend migrates incrementally.
+
 ## Development
 
 ### Frontend

--- a/api/app/core/settings.py
+++ b/api/app/core/settings.py
@@ -8,7 +8,9 @@ from pathlib import Path
 @dataclass(frozen=True)
 class Settings:
     app_name: str = "Hermes Control Plane API"
+    app_version: str = "0.1.0"
     api_prefix: str = "/api"
+    dashboard_api_version: str = "v1alpha1"
     hermes_home: Path = Path(os.getenv("HERMES_HOME", "/opt/data")).expanduser()
     hermes_bin: Path = Path(os.getenv("HERMES_BIN", "/opt/hermes/.venv/bin/hermes")).expanduser()
     hermes_root: Path = Path(

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -9,6 +9,11 @@ from fastapi.responses import FileResponse
 
 from app.core.settings import settings
 from app.models import (
+    AgentDefaults,
+    AgentFiles,
+    AgentRuntimeHints,
+    AgentsResponse,
+    AgentSummary,
     ConfigSummary,
     CreateProfileRequest,
     HealthResponse,
@@ -17,12 +22,15 @@ from app.models import (
     SkillBroadcastResult,
     SkillsResponse,
     StatusResponse,
+    SystemHealthResponse,
+    SystemVersionResponse,
 )
 from app.services.hermes_adapter import (
     active_profile_name,
     broadcast_skill_configuration,
     config_summary,
     create_profile,
+    ensure_profile_exists,
     list_cron_jobs,
     list_sessions,
     list_skills,
@@ -32,7 +40,34 @@ from app.services.hermes_adapter import (
     status_payload,
 )
 
-app = FastAPI(title=settings.app_name, version="0.1.0")
+app = FastAPI(title=settings.app_name, version=settings.app_version)
+
+
+def adapter_descriptor() -> dict[str, str | bool]:
+    return {
+        "kind": "hermes-dashboard-api",
+        "hermes_home": str(settings.hermes_home),
+        "hermes_bin": str(settings.hermes_bin),
+        "hermes_bin_exists": settings.hermes_bin.exists(),
+    }
+
+
+def agent_contract(summary: AgentSummary | object) -> AgentSummary:
+    if isinstance(summary, AgentSummary):
+        return summary
+    if not hasattr(summary, "name"):
+        raise TypeError("Expected profile summary-like object")
+    return AgentSummary(
+        id=summary.name,
+        name=summary.name,
+        path=summary.path,
+        is_active=summary.is_active,
+        exists=summary.exists,
+        defaults=AgentDefaults(model=summary.model, provider=summary.provider),
+        files=AgentFiles(has_env_file=summary.has_env_file, has_soul_file=summary.has_soul_file),
+        runtime_hints=AgentRuntimeHints(gateway_state=summary.gateway_state, skill_count=summary.skill_count),
+    )
+
 
 # ── API routes ────────────────────────────────────────────────────────────
 
@@ -47,9 +82,43 @@ def get_health() -> HealthResponse:
     )
 
 
+@app.get("/api/system/health", response_model=SystemHealthResponse, tags=["system"])
+def get_system_health() -> SystemHealthResponse:
+    return SystemHealthResponse(
+        status="ok",
+        service=settings.app_name,
+        api_version=settings.dashboard_api_version,
+        app_version=settings.app_version,
+        adapter=adapter_descriptor(),
+    )
+
+
+@app.get("/api/system/version", response_model=SystemVersionResponse, tags=["system"])
+def get_system_version() -> SystemVersionResponse:
+    return SystemVersionResponse(
+        service=settings.app_name,
+        api_version=settings.dashboard_api_version,
+        app_version=settings.app_version,
+    )
+
+
 @app.get("/api/status", response_model=StatusResponse, tags=["system"])
 def get_status() -> StatusResponse:
     return StatusResponse(**status_payload())
+
+
+@app.get("/api/agents", response_model=AgentsResponse, tags=["agents"])
+def get_agents() -> AgentsResponse:
+    active = active_profile_name()
+    agents = [agent_contract(profile_summary(context, active_profile=active)) for context in profile_contexts()]
+    return AgentsResponse(agents=agents, active_agent_id=active, total=len(agents))
+
+
+@app.get("/api/agents/{agent_id}", response_model=AgentSummary, tags=["agents"])
+def get_agent(agent_id: str) -> AgentSummary:
+    active = active_profile_name()
+    context = ensure_profile_exists(agent_id)
+    return agent_contract(profile_summary(context, active_profile=active))
 
 
 @app.get("/api/profiles", tags=["profiles"])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -13,6 +13,59 @@ class HealthResponse(BaseModel):
     hermes_bin_exists: bool
 
 
+class AdapterDescriptor(BaseModel):
+    kind: str
+    hermes_home: str
+    hermes_bin: str
+    hermes_bin_exists: bool
+
+
+class SystemHealthResponse(BaseModel):
+    status: Literal["ok"]
+    service: str
+    api_version: str
+    app_version: str
+    adapter: AdapterDescriptor
+
+
+class SystemVersionResponse(BaseModel):
+    service: str
+    api_version: str
+    app_version: str
+
+
+class AgentDefaults(BaseModel):
+    model: str | None = None
+    provider: str | None = None
+
+
+class AgentFiles(BaseModel):
+    has_env_file: bool = False
+    has_soul_file: bool = False
+
+
+class AgentRuntimeHints(BaseModel):
+    gateway_state: str | None = None
+    skill_count: int = 0
+
+
+class AgentSummary(BaseModel):
+    id: str
+    name: str
+    path: str
+    is_active: bool = False
+    exists: bool = True
+    defaults: AgentDefaults
+    files: AgentFiles
+    runtime_hints: AgentRuntimeHints
+
+
+class AgentsResponse(BaseModel):
+    agents: list[AgentSummary]
+    active_agent_id: str
+    total: int
+
+
 class CommandResult(BaseModel):
     command: list[str]
     exit_code: int

--- a/api/tests/test_dashboard_api_contracts.py
+++ b/api/tests/test_dashboard_api_contracts.py
@@ -1,0 +1,139 @@
+from fastapi.testclient import TestClient
+
+from app.core.settings import settings
+from app.main import app
+from app.models import ProfileSummary
+from app.services import hermes_adapter
+
+
+client = TestClient(app)
+
+
+def test_system_health_contract_is_available() -> None:
+    response = client.get('/api/system/health')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        'status': 'ok',
+        'service': 'Hermes Control Plane API',
+        'api_version': 'v1alpha1',
+        'app_version': '0.1.0',
+        'adapter': {
+            'kind': 'hermes-dashboard-api',
+            'hermes_home': '/opt/data',
+            'hermes_bin': '/opt/hermes/.venv/bin/hermes',
+            'hermes_bin_exists': settings.hermes_bin.exists(),
+        },
+    }
+
+
+def test_system_version_contract_is_available() -> None:
+    response = client.get('/api/system/version')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        'service': 'Hermes Control Plane API',
+        'api_version': 'v1alpha1',
+        'app_version': '0.1.0',
+    }
+
+
+def test_agents_collection_uses_stable_dashboard_contract(monkeypatch) -> None:
+    monkeypatch.setattr('app.main.active_profile_name', lambda: 'default')
+    monkeypatch.setattr(
+        'app.main.profile_contexts',
+        lambda: [hermes_adapter.HermesContext(profile='default'), hermes_adapter.HermesContext(profile='nightowl')],
+    )
+
+    summaries = {
+        'default': ProfileSummary(
+            name='default',
+            path='/opt/data',
+            is_active=True,
+            exists=True,
+            model='gpt-5.4',
+            provider='custom',
+            gateway_state='online',
+            has_env_file=True,
+            has_soul_file=True,
+            skill_count=12,
+        ),
+        'nightowl': ProfileSummary(
+            name='nightowl',
+            path='/opt/data/profiles/nightowl',
+            is_active=False,
+            exists=True,
+            model='opus',
+            provider='airouter',
+            gateway_state='offline',
+            has_env_file=True,
+            has_soul_file=False,
+            skill_count=4,
+        ),
+    }
+    monkeypatch.setattr('app.main.profile_summary', lambda context, active_profile: summaries[context.profile])
+
+    response = client.get('/api/agents')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['active_agent_id'] == 'default'
+    assert payload['total'] == 2
+    assert payload['agents'] == [
+        {
+            'id': 'default',
+            'name': 'default',
+            'path': '/opt/data',
+            'is_active': True,
+            'exists': True,
+            'defaults': {'model': 'gpt-5.4', 'provider': 'custom'},
+            'files': {'has_env_file': True, 'has_soul_file': True},
+            'runtime_hints': {'gateway_state': 'online', 'skill_count': 12},
+        },
+        {
+            'id': 'nightowl',
+            'name': 'nightowl',
+            'path': '/opt/data/profiles/nightowl',
+            'is_active': False,
+            'exists': True,
+            'defaults': {'model': 'opus', 'provider': 'airouter'},
+            'files': {'has_env_file': True, 'has_soul_file': False},
+            'runtime_hints': {'gateway_state': 'offline', 'skill_count': 4},
+        },
+    ]
+
+
+def test_agent_detail_contract_is_available(monkeypatch) -> None:
+    monkeypatch.setattr('app.main.active_profile_name', lambda: 'nightowl')
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: hermes_adapter.HermesContext(profile=agent_id))
+    monkeypatch.setattr(
+        'app.main.profile_summary',
+        lambda context, active_profile: ProfileSummary(
+            name=context.profile,
+            path=f'/opt/data/profiles/{context.profile}',
+            is_active=context.profile == active_profile,
+            exists=True,
+            model='opus',
+            provider='airouter',
+            gateway_state='online',
+            has_env_file=True,
+            has_soul_file=True,
+            skill_count=9,
+        ),
+    )
+
+    response = client.get('/api/agents/nightowl')
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'id': 'nightowl',
+        'name': 'nightowl',
+        'path': '/opt/data/profiles/nightowl',
+        'is_active': True,
+        'exists': True,
+        'defaults': {'model': 'opus', 'provider': 'airouter'},
+        'files': {'has_env_file': True, 'has_soul_file': True},
+        'runtime_hints': {'gateway_state': 'online', 'skill_count': 9},
+    }

--- a/api/tests/test_dashboard_api_contracts.py
+++ b/api/tests/test_dashboard_api_contracts.py
@@ -16,13 +16,13 @@ def test_system_health_contract_is_available() -> None:
     payload = response.json()
     assert payload == {
         'status': 'ok',
-        'service': 'Hermes Control Plane API',
-        'api_version': 'v1alpha1',
-        'app_version': '0.1.0',
+        'service': settings.app_name,
+        'api_version': settings.dashboard_api_version,
+        'app_version': settings.app_version,
         'adapter': {
             'kind': 'hermes-dashboard-api',
-            'hermes_home': '/opt/data',
-            'hermes_bin': '/opt/hermes/.venv/bin/hermes',
+            'hermes_home': str(settings.hermes_home),
+            'hermes_bin': str(settings.hermes_bin),
             'hermes_bin_exists': settings.hermes_bin.exists(),
         },
     }
@@ -34,9 +34,9 @@ def test_system_version_contract_is_available() -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload == {
-        'service': 'Hermes Control Plane API',
-        'api_version': 'v1alpha1',
-        'app_version': '0.1.0',
+        'service': settings.app_name,
+        'api_version': settings.dashboard_api_version,
+        'app_version': settings.app_version,
     }
 
 


### PR DESCRIPTION
## Summary
- add initial stable dashboard adapter contracts for `/api/system/*` and `/api/agents*`
- keep legacy Phase 1 endpoints available while the frontend migrates incrementally
- document the contract foundation in the README and cover it with backend tests

## Test Plan
- `/opt/hermes/.venv/bin/python -m pytest api/tests/test_dashboard_api_contracts.py -q`
- `/opt/hermes/.venv/bin/python -m pytest api/tests -q`
- `npm run build`
- `npm run lint`

Closes #2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added system health and version API endpoints to monitor service status and capabilities.
  * Added agent discovery endpoints to list all agents and retrieve individual agent details by identifier.
  * Introduced configurable application version settings.

* **Documentation**
  * Updated documentation specifying newly exposed stable dashboard adapter endpoints.

* **Tests**
  * Added comprehensive tests for new API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->