### PR TITLE
feat: add runtime registry capsules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The control-plane backend now exposes an initial stable dashboard adapter surfac
 - `GET /api/system/version`
 - `GET /api/agents`
 - `GET /api/agents/{agent_id}`
+- `GET /api/agents/runtimes`
+- `GET /api/agents/{agent_id}/runtime`
 
 These routes are the first step toward the architecture-spec split between
 agent-scoped and system-scoped resources. Legacy Phase 1 routes such as

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -4,14 +4,16 @@ import os
 from pathlib import Path
 
 from fastapi import FastAPI, Query
-from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from app.core.settings import settings
 from app.models import (
     AgentDefaults,
     AgentFiles,
+    AgentRuntimeCollection,
     AgentRuntimeHints,
+    AgentRuntimeSummary,
     AgentsResponse,
     AgentSummary,
     ConfigSummary,
@@ -39,24 +41,25 @@ from app.services.hermes_adapter import (
     profile_summary,
     status_payload,
 )
+from app.services.runtime_registry import runtime_registry
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
 
 
 def adapter_descriptor() -> dict[str, str | bool]:
     return {
-        "kind": "hermes-dashboard-api",
-        "hermes_home": str(settings.hermes_home),
-        "hermes_bin": str(settings.hermes_bin),
-        "hermes_bin_exists": settings.hermes_bin.exists(),
+        'kind': 'hermes-dashboard-api',
+        'hermes_home': str(settings.hermes_home),
+        'hermes_bin': str(settings.hermes_bin),
+        'hermes_bin_exists': settings.hermes_bin.exists(),
     }
 
 
 def agent_contract(summary: AgentSummary | object) -> AgentSummary:
     if isinstance(summary, AgentSummary):
         return summary
-    if not hasattr(summary, "name"):
-        raise TypeError("Expected profile summary-like object")
+    if not hasattr(summary, 'name'):
+        raise TypeError('Expected profile summary-like object')
     return AgentSummary(
         id=summary.name,
         name=summary.name,
@@ -69,9 +72,7 @@ def agent_contract(summary: AgentSummary | object) -> AgentSummary:
     )
 
 
-# ── API routes ────────────────────────────────────────────────────────────
-
-@app.get("/api/health", response_model=HealthResponse, tags=["system"])
+@app.get('/api/health', response_model=HealthResponse, tags=['system'])
 def get_health() -> HealthResponse:
     return HealthResponse(
         ok=True,
@@ -82,10 +83,10 @@ def get_health() -> HealthResponse:
     )
 
 
-@app.get("/api/system/health", response_model=SystemHealthResponse, tags=["system"])
+@app.get('/api/system/health', response_model=SystemHealthResponse, tags=['system'])
 def get_system_health() -> SystemHealthResponse:
     return SystemHealthResponse(
-        status="ok",
+        status='ok',
         service=settings.app_name,
         api_version=settings.dashboard_api_version,
         app_version=settings.app_version,
@@ -93,7 +94,7 @@ def get_system_health() -> SystemHealthResponse:
     )
 
 
-@app.get("/api/system/version", response_model=SystemVersionResponse, tags=["system"])
+@app.get('/api/system/version', response_model=SystemVersionResponse, tags=['system'])
 def get_system_version() -> SystemVersionResponse:
     return SystemVersionResponse(
         service=settings.app_name,
@@ -102,33 +103,44 @@ def get_system_version() -> SystemVersionResponse:
     )
 
 
-@app.get("/api/status", response_model=StatusResponse, tags=["system"])
+@app.get('/api/status', response_model=StatusResponse, tags=['system'])
 def get_status() -> StatusResponse:
     return StatusResponse(**status_payload())
 
 
-@app.get("/api/agents", response_model=AgentsResponse, tags=["agents"])
+@app.get('/api/agents', response_model=AgentsResponse, tags=['agents'])
 def get_agents() -> AgentsResponse:
     active = active_profile_name()
     agents = [agent_contract(profile_summary(context, active_profile=active)) for context in profile_contexts()]
     return AgentsResponse(agents=agents, active_agent_id=active, total=len(agents))
 
 
-@app.get("/api/agents/{agent_id}", response_model=AgentSummary, tags=["agents"])
+@app.get('/api/agents/runtimes', response_model=AgentRuntimeCollection, tags=['agents'])
+def get_agent_runtimes() -> AgentRuntimeCollection:
+    runtimes = runtime_registry.list_runtimes()
+    return AgentRuntimeCollection(runtimes=runtimes, total=len(runtimes))
+
+
+@app.get('/api/agents/{agent_id}/runtime', response_model=AgentRuntimeSummary, tags=['agents'])
+def get_agent_runtime(agent_id: str) -> AgentRuntimeSummary:
+    return runtime_registry.get_runtime(agent_id)
+
+
+@app.get('/api/agents/{agent_id}', response_model=AgentSummary, tags=['agents'])
 def get_agent(agent_id: str) -> AgentSummary:
     active = active_profile_name()
     context = ensure_profile_exists(agent_id)
     return agent_contract(profile_summary(context, active_profile=active))
 
 
-@app.get("/api/profiles", tags=["profiles"])
+@app.get('/api/profiles', tags=['profiles'])
 def get_profiles() -> dict:
     active = active_profile_name()
     profiles = [profile_summary(context, active_profile=active).model_dump() for context in profile_contexts()]
-    return {"profiles": profiles, "active_profile": active}
+    return {'profiles': profiles, 'active_profile': active}
 
 
-@app.post("/api/profiles", tags=["profiles"])
+@app.post('/api/profiles', tags=['profiles'])
 def post_profiles(payload: CreateProfileRequest) -> dict:
     result = create_profile(
         profile_name=payload.profile_name,
@@ -137,21 +149,21 @@ def post_profiles(payload: CreateProfileRequest) -> dict:
         clone_from=payload.clone_from,
         no_alias=payload.no_alias,
     )
-    return {"ok": True, "stdout": result.stdout, "stderr": result.stderr}
+    return {'ok': True, 'stdout': result.stdout, 'stderr': result.stderr}
 
 
-@app.get("/api/sessions", tags=["sessions"])
-def get_sessions(profile: str = Query("default")) -> dict:
-    return {"profile": profile, "sessions": [item.model_dump() for item in list_sessions(profile)]}
+@app.get('/api/sessions', tags=['sessions'])
+def get_sessions(profile: str = Query('default')) -> dict:
+    return {'profile': profile, 'sessions': [item.model_dump() for item in list_sessions(profile)]}
 
 
-@app.get("/api/skills", response_model=SkillsResponse, tags=["skills"])
-def get_skills(profile: str = Query("default")) -> SkillsResponse:
+@app.get('/api/skills', response_model=SkillsResponse, tags=['skills'])
+def get_skills(profile: str = Query('default')) -> SkillsResponse:
     skills = list_skills(profile)
     return SkillsResponse(profile=profile, total=len(skills), skills=skills)
 
 
-@app.post("/api/skills/broadcast", response_model=SkillBroadcastResult, tags=["skills"])
+@app.post('/api/skills/broadcast', response_model=SkillBroadcastResult, tags=['skills'])
 def post_skill_broadcast(payload: SkillBroadcastRequest) -> SkillBroadcastResult:
     copied = broadcast_skill_configuration(
         source_profile=payload.source_profile,
@@ -168,35 +180,31 @@ def post_skill_broadcast(payload: SkillBroadcastRequest) -> SkillBroadcastResult
     )
 
 
-@app.get("/api/cron/jobs", tags=["cron"])
-def get_cron_jobs(profile: str = Query("default")) -> dict:
+@app.get('/api/cron/jobs', tags=['cron'])
+def get_cron_jobs(profile: str = Query('default')) -> dict:
     jobs = list_cron_jobs(profile)
-    return {"profile": profile, "jobs": [job.model_dump() for job in jobs], "total": len(jobs)}
+    return {'profile': profile, 'jobs': [job.model_dump() for job in jobs], 'total': len(jobs)}
 
 
-@app.get("/api/logs", response_model=LogEntry, tags=["logs"])
+@app.get('/api/logs', response_model=LogEntry, tags=['logs'])
 def get_logs(
-    profile: str = Query("default"),
-    log_name: str = Query("agent"),
+    profile: str = Query('default'),
+    log_name: str = Query('agent'),
     lines: int = Query(100, ge=1, le=500),
 ) -> LogEntry:
     return LogEntry(**log_payload(profile=profile, log_name=log_name, lines=lines))
 
 
-@app.get("/api/config/summary", response_model=ConfigSummary, tags=["config"])
-def get_config_summary(profile: str = Query("default")) -> ConfigSummary:
+@app.get('/api/config/summary', response_model=ConfigSummary, tags=['config'])
+def get_config_summary(profile: str = Query('default')) -> ConfigSummary:
     return ConfigSummary(**config_summary(profile))
 
 
-# ── Frontend static files (SPA catch-all) ────────────────────────────────
+STATIC_DIR = Path(os.environ.get('STATIC_DIR', '/app/static'))
 
-STATIC_DIR = Path(os.environ.get("STATIC_DIR", "/app/static"))
-
-# Mount static assets (js, css, images)
 if STATIC_DIR.is_dir():
-    app.mount("/assets", StaticFiles(directory=STATIC_DIR / "assets"), name="static-assets")
+    app.mount('/assets', StaticFiles(directory=STATIC_DIR / 'assets'), name='static-assets')
 
-    @app.get("/{full_path:path}")
+    @app.get('/{full_path:path}')
     def serve_spa(full_path: str):
-        """Catch-all: serve index.html for SPA routing."""
-        return FileResponse(STATIC_DIR / "index.html")
+        return FileResponse(STATIC_DIR / 'index.html')

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -66,6 +66,24 @@ class AgentsResponse(BaseModel):
     total: int
 
 
+class AgentRuntimeSummary(BaseModel):
+    agent_id: str
+    status: Literal["active", "idle", "degraded", "missing"]
+    active_run_count: int = 0
+    active_session_count: int = 0
+    active_session_id: str | None = None
+    effective_provider: str | None = None
+    effective_model: str | None = None
+    mcp_status: str | None = None
+    gateway_status: str | None = None
+    last_activity_at: str | None = None
+
+
+class AgentRuntimeCollection(BaseModel):
+    runtimes: list[AgentRuntimeSummary]
+    total: int
+
+
 class CommandResult(BaseModel):
     command: list[str]
     exit_code: int

--- a/api/app/services/runtime_registry.py
+++ b/api/app/services/runtime_registry.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from fastapi import HTTPException
+
+from app.models import AgentRuntimeSummary, ProfileSummary, SessionSummary
+from app.services.hermes_adapter import HermesContext, active_profile_name, ensure_profile_exists, list_sessions, profile_contexts, profile_summary
+from app.utils import load_yaml_file
+
+
+@dataclass
+class RuntimeRegistry:
+    contexts_provider: Callable[[], list[HermesContext]] = profile_contexts
+    active_profile_provider: Callable[[], str] = active_profile_name
+    profile_summary_provider: Callable[[HermesContext, str], ProfileSummary] = profile_summary
+    session_reader: Callable[[str], list[SessionSummary]] = list_sessions
+    active_run_counter: Callable[[str], int] | None = None
+    mcp_status_provider: Callable[[str], str | None] | None = None
+
+    def list_runtimes(self) -> list[AgentRuntimeSummary]:
+        return [self.get_runtime(context.profile) for context in self.contexts_provider()]
+
+    def list_runtime_capsules(self) -> dict:
+        runtimes = self.list_runtimes()
+        return {'runtimes': [runtime.model_dump() for runtime in runtimes], 'total': len(runtimes)}
+
+    def get_runtime(self, agent_id: str) -> AgentRuntimeSummary:
+        active_profile = self.active_profile_provider()
+        context = next((item for item in self.contexts_provider() if item.profile == agent_id), None)
+        if context is None:
+            context = ensure_profile_exists(agent_id)
+        summary = self.profile_summary_provider(context, active_profile)
+        sessions = self.session_reader(agent_id)
+        active_run_count = self._active_run_count(agent_id)
+        last_activity = self._last_activity_at(sessions)
+        latest_session_id = self._latest_session_id(sessions, last_activity)
+        return AgentRuntimeSummary(
+            agent_id=agent_id,
+            status=self._status_for(summary=summary, session_count=len(sessions), active_run_count=active_run_count),
+            active_run_count=active_run_count,
+            active_session_count=len(sessions),
+            active_session_id=latest_session_id,
+            effective_provider=summary.provider,
+            effective_model=summary.model,
+            mcp_status=self._mcp_status(agent_id, context),
+            gateway_status=summary.gateway_state,
+            last_activity_at=last_activity,
+        )
+
+    def get_runtime_capsule(self, agent_id: str) -> dict:
+        return self.get_runtime(agent_id).model_dump()
+
+    def _active_run_count(self, agent_id: str) -> int:
+        if self.active_run_counter is None:
+            return 0
+        return max(self.active_run_counter(agent_id), 0)
+
+    def _mcp_status(self, agent_id: str, context: HermesContext) -> str | None:
+        if self.mcp_status_provider is not None:
+            return self.mcp_status_provider(agent_id)
+        config = load_yaml_file(context.home / 'config.yaml')
+        servers = config.get('mcp_servers') or config.get('mcpServers')
+        if isinstance(servers, dict) and servers:
+            return 'configured'
+        return 'idle'
+
+    @staticmethod
+    def _last_activity_at(sessions: list[SessionSummary]) -> str | None:
+        timestamps = [session.last_active for session in sessions if session.last_active]
+        return max(timestamps) if timestamps else None
+
+    @staticmethod
+    def _latest_session_id(sessions: list[SessionSummary], last_activity: str | None) -> str | None:
+        if not last_activity:
+            return None
+        for session in sessions:
+            if session.last_active == last_activity:
+                return session.id
+        return None
+
+    @staticmethod
+    def _status_for(*, summary: ProfileSummary, session_count: int, active_run_count: int) -> str:
+        if not summary.exists:
+            return 'missing'
+        if active_run_count > 0 or session_count > 0 or summary.is_active:
+            return 'active'
+        if summary.gateway_state == 'online':
+            return 'active'
+        if summary.gateway_state in {'offline', 'error'}:
+            return 'idle'
+        return 'degraded'
+
+
+registry = RuntimeRegistry()
+runtime_registry = registry
+
+
+def list_runtime_capsules() -> dict:
+    return registry.list_runtime_capsules()
+
+
+def get_runtime_capsule(agent_id: str) -> dict:
+    return registry.get_runtime_capsule(agent_id)

--- a/api/app/services/runtime_registry.py
+++ b/api/app/services/runtime_registry.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable
 
-from fastapi import HTTPException
-
 from app.models import AgentRuntimeSummary, ProfileSummary, SessionSummary
-from app.services.hermes_adapter import HermesContext, active_profile_name, ensure_profile_exists, list_sessions, profile_contexts, profile_summary
+from app.services.hermes_adapter import (
+    HermesContext,
+    active_profile_name,
+    ensure_profile_exists,
+    list_sessions,
+    profile_contexts,
+    profile_summary,
+)
 from app.utils import load_yaml_file
 
 
@@ -86,10 +91,10 @@ class RuntimeRegistry:
             return 'missing'
         if active_run_count > 0 or session_count > 0 or summary.is_active:
             return 'active'
-        if summary.gateway_state == 'online':
-            return 'active'
         if summary.gateway_state in {'offline', 'error'}:
             return 'idle'
+        if summary.gateway_state == 'online':
+            return 'active'
         return 'degraded'
 
 

--- a/api/tests/test_runtime_registry.py
+++ b/api/tests/test_runtime_registry.py
@@ -1,0 +1,157 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models import AgentRuntimeSummary, ProfileSummary, SessionSummary
+from app.services.hermes_adapter import HermesContext
+from app.services.runtime_registry import RuntimeRegistry
+
+
+client = TestClient(app)
+
+
+def _profile_summary(*, name: str, is_active: bool, gateway_state: str | None, model: str, provider: str) -> ProfileSummary:
+    return ProfileSummary(
+        name=name,
+        path=f'/opt/data/profiles/{name}' if name != 'default' else '/opt/data',
+        is_active=is_active,
+        exists=True,
+        model=model,
+        provider=provider,
+        gateway_state=gateway_state,
+        has_env_file=True,
+        has_soul_file=name == 'default',
+        skill_count=3,
+    )
+
+
+def test_runtime_registry_builds_profile_scoped_capsule_summary() -> None:
+    registry = RuntimeRegistry(
+        contexts_provider=lambda: [HermesContext(profile='default'), HermesContext(profile='nightowl')],
+        active_profile_provider=lambda: 'nightowl',
+        profile_summary_provider=lambda context, active_profile: {
+            'default': _profile_summary(
+                name='default',
+                is_active=False,
+                gateway_state='offline',
+                model='gpt-5.4',
+                provider='custom',
+            ),
+            'nightowl': _profile_summary(
+                name='nightowl',
+                is_active=True,
+                gateway_state='online',
+                model='opus',
+                provider='airouter',
+            ),
+        }[context.profile],
+        session_reader=lambda profile: [
+            SessionSummary(id='sess-1', title='Earlier', preview='...', last_active='2026-04-23T14:00:00Z'),
+            SessionSummary(id='sess-2', title='Latest', preview='...', last_active='2026-04-23T16:00:00Z'),
+        ]
+        if profile == 'nightowl'
+        else [],
+        active_run_counter=lambda profile: 2 if profile == 'nightowl' else 0,
+        mcp_status_provider=lambda profile: 'connected' if profile == 'nightowl' else 'idle',
+    )
+
+    runtime = registry.get_runtime('nightowl')
+
+    assert runtime == AgentRuntimeSummary(
+        agent_id='nightowl',
+        status='active',
+        active_run_count=2,
+        active_session_count=2,
+        active_session_id='sess-2',
+        effective_provider='airouter',
+        effective_model='opus',
+        mcp_status='connected',
+        gateway_status='online',
+        last_activity_at='2026-04-23T16:00:00Z',
+    )
+
+
+def test_agent_runtime_endpoint_uses_registry_contract(monkeypatch) -> None:
+    registry = RuntimeRegistry(
+        contexts_provider=lambda: [HermesContext(profile='nightowl')],
+        active_profile_provider=lambda: 'nightowl',
+        profile_summary_provider=lambda context, active_profile: _profile_summary(
+            name=context.profile,
+            is_active=True,
+            gateway_state='online',
+            model='opus',
+            provider='airouter',
+        ),
+        session_reader=lambda profile: [
+            SessionSummary(id='sess-9', title='Runtime', preview='...', last_active='2026-04-23T16:15:00Z')
+        ],
+        active_run_counter=lambda profile: 1,
+        mcp_status_provider=lambda profile: 'connected',
+    )
+    monkeypatch.setattr('app.main.runtime_registry', registry)
+
+    response = client.get('/api/agents/nightowl/runtime')
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'agent_id': 'nightowl',
+        'status': 'active',
+        'active_run_count': 1,
+        'active_session_count': 1,
+        'active_session_id': 'sess-9',
+        'effective_provider': 'airouter',
+        'effective_model': 'opus',
+        'mcp_status': 'connected',
+        'gateway_status': 'online',
+        'last_activity_at': '2026-04-23T16:15:00Z',
+    }
+
+
+def test_agent_runtime_collection_lists_all_runtime_capsules(monkeypatch) -> None:
+    registry = RuntimeRegistry(
+        contexts_provider=lambda: [HermesContext(profile='default'), HermesContext(profile='nightowl')],
+        active_profile_provider=lambda: 'default',
+        profile_summary_provider=lambda context, active_profile: _profile_summary(
+            name=context.profile,
+            is_active=context.profile == active_profile,
+            gateway_state='online' if context.profile == 'default' else 'offline',
+            model='gpt-5.4' if context.profile == 'default' else 'opus',
+            provider='custom' if context.profile == 'default' else 'airouter',
+        ),
+        session_reader=lambda profile: [],
+        active_run_counter=lambda profile: 0,
+        mcp_status_provider=lambda profile: 'idle',
+    )
+    monkeypatch.setattr('app.main.runtime_registry', registry)
+
+    response = client.get('/api/agents/runtimes')
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'runtimes': [
+            {
+                'agent_id': 'default',
+                'status': 'active',
+                'active_run_count': 0,
+                'active_session_count': 0,
+                'active_session_id': None,
+                'effective_provider': 'custom',
+                'effective_model': 'gpt-5.4',
+                'mcp_status': 'idle',
+                'gateway_status': 'online',
+                'last_activity_at': None,
+            },
+            {
+                'agent_id': 'nightowl',
+                'status': 'idle',
+                'active_run_count': 0,
+                'active_session_count': 0,
+                'active_session_id': None,
+                'effective_provider': 'airouter',
+                'effective_model': 'opus',
+                'mcp_status': 'idle',
+                'gateway_status': 'offline',
+                'last_activity_at': None,
+            },
+        ],
+        'total': 2,
+    }


### PR DESCRIPTION
## Summary
- add a backend runtime registry abstraction for profile-scoped runtime capsules
- expose agent runtime collection/detail endpoints backed by the registry
- cover the registry and endpoints with test-first backend coverage

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_runtime_registry.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run build
- npm run lint

Closes #3