### PR TITLE
feat: add console runs contracts

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 from fastapi import FastAPI, Query
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.core.settings import settings
@@ -20,6 +20,9 @@ from app.models import (
     CreateProfileRequest,
     HealthResponse,
     LogEntry,
+    RunCreateRequest,
+    RunSummary,
+    RunsResponse,
     SkillBroadcastRequest,
     SkillBroadcastResult,
     SkillsResponse,
@@ -41,6 +44,7 @@ from app.services.hermes_adapter import (
     profile_summary,
     status_payload,
 )
+from app.services.run_service import run_service
 from app.services.runtime_registry import runtime_registry
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
@@ -119,6 +123,43 @@ def get_agents() -> AgentsResponse:
 def get_agent_runtimes() -> AgentRuntimeCollection:
     runtimes = runtime_registry.list_runtimes()
     return AgentRuntimeCollection(runtimes=runtimes, total=len(runtimes))
+
+
+@app.post('/api/agents/{agent_id}/runs', response_model=RunSummary, status_code=201, tags=['runs'])
+def create_run(agent_id: str, payload: RunCreateRequest) -> RunSummary:
+    ensure_profile_exists(agent_id)
+    return run_service.create_run(agent_id, payload)
+
+
+@app.get('/api/agents/{agent_id}/runs', response_model=RunsResponse, tags=['runs'])
+def list_runs(agent_id: str) -> RunsResponse:
+    ensure_profile_exists(agent_id)
+    runs = run_service.list_runs(agent_id)
+    return RunsResponse(runs=runs, total=len(runs))
+
+
+@app.get('/api/agents/{agent_id}/runs/{run_id}', response_model=RunSummary, tags=['runs'])
+def get_run(agent_id: str, run_id: str) -> RunSummary:
+    ensure_profile_exists(agent_id)
+    return run_service.get_run(agent_id, run_id)
+
+
+@app.post('/api/agents/{agent_id}/runs/{run_id}/stop', response_model=RunSummary, tags=['runs'])
+def stop_run(agent_id: str, run_id: str) -> RunSummary:
+    ensure_profile_exists(agent_id)
+    return run_service.stop_run(agent_id, run_id)
+
+
+@app.get('/api/agents/{agent_id}/runs/{run_id}/stream', tags=['runs'])
+def stream_run(agent_id: str, run_id: str) -> StreamingResponse:
+    ensure_profile_exists(agent_id)
+    return StreamingResponse(iter([run_service.event_stream_payload(agent_id, run_id)]), media_type='text/event-stream')
+
+
+@app.get('/api/agents/{agent_id}/runs/{run_id}/events', tags=['runs'])
+def get_run_events(agent_id: str, run_id: str) -> StreamingResponse:
+    ensure_profile_exists(agent_id)
+    return StreamingResponse(iter([run_service.event_stream_payload(agent_id, run_id)]), media_type='text/event-stream')
 
 
 @app.get('/api/agents/{agent_id}/runtime', response_model=AgentRuntimeSummary, tags=['agents'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -84,6 +84,30 @@ class AgentRuntimeCollection(BaseModel):
     total: int
 
 
+class RunCreateRequest(BaseModel):
+    session_id: str | None = None
+    input: str
+
+
+class RunSummary(BaseModel):
+    id: str
+    agent_id: str
+    session_id: str | None = None
+    status: Literal['queued', 'running', 'completed', 'failed', 'stopped']
+    started_at: str
+    ended_at: str | None = None
+    current_model: str | None = None
+    current_provider: str | None = None
+    summary: str | None = None
+    stream_url: str
+    events_url: str
+
+
+class RunsResponse(BaseModel):
+    runs: list[RunSummary]
+    total: int
+
+
 class CommandResult(BaseModel):
     command: list[str]
     exit_code: int

--- a/api/app/services/run_service.py
+++ b/api/app/services/run_service.py
@@ -4,6 +4,7 @@ import json
 from collections import defaultdict
 from datetime import UTC, datetime
 from itertools import count
+from threading import RLock
 from typing import DefaultDict
 
 from fastapi import HTTPException
@@ -19,46 +20,51 @@ class RunService:
     def __init__(self) -> None:
         self._runs_by_agent: DefaultDict[str, list[RunSummary]] = defaultdict(list)
         self._id_counter = count(1)
+        self._lock = RLock()
 
     def create_run(self, agent_id: str, payload: RunCreateRequest) -> RunSummary:
-        run_id = f'run-{next(self._id_counter):04d}'
-        started_at = _iso_now()
-        run = RunSummary(
-            id=run_id,
-            agent_id=agent_id,
-            session_id=payload.session_id,
-            status='queued',
-            started_at=started_at,
-            ended_at=None,
-            current_model=None,
-            current_provider=None,
-            summary=payload.input,
-            stream_url=f'/api/agents/{agent_id}/runs/{run_id}/stream',
-            events_url=f'/api/agents/{agent_id}/runs/{run_id}/events',
-        )
-        self._runs_by_agent[agent_id].insert(0, run)
-        return run
+        with self._lock:
+            run_id = f'run-{next(self._id_counter):04d}'
+            started_at = _iso_now()
+            run = RunSummary(
+                id=run_id,
+                agent_id=agent_id,
+                session_id=payload.session_id,
+                status='queued',
+                started_at=started_at,
+                ended_at=None,
+                current_model=None,
+                current_provider=None,
+                summary=payload.input,
+                stream_url=f'/api/agents/{agent_id}/runs/{run_id}/stream',
+                events_url=f'/api/agents/{agent_id}/runs/{run_id}/events',
+            )
+            self._runs_by_agent[agent_id].insert(0, run)
+            return run
 
     def list_runs(self, agent_id: str) -> list[RunSummary]:
-        return list(self._runs_by_agent[agent_id])
+        with self._lock:
+            return list(self._runs_by_agent[agent_id])
 
     def get_run(self, agent_id: str, run_id: str) -> RunSummary:
-        for run in self._runs_by_agent[agent_id]:
-            if run.id == run_id:
-                return run
+        with self._lock:
+            for run in self._runs_by_agent[agent_id]:
+                if run.id == run_id:
+                    return run
         raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
 
     def stop_run(self, agent_id: str, run_id: str) -> RunSummary:
-        run = self.get_run(agent_id, run_id)
-        if run.status in {'completed', 'failed', 'stopped'}:
-            return run
-        updated = run.model_copy(update={'status': 'stopped', 'ended_at': _iso_now()})
-        self._replace_run(agent_id, updated)
-        return updated
+        with self._lock:
+            run = self.get_run(agent_id, run_id)
+            if run.status in {'completed', 'failed', 'stopped'}:
+                return run
+            updated = run.model_copy(update={'status': 'stopped', 'ended_at': _iso_now()})
+            self._replace_run(agent_id, updated)
+            return updated
 
     def event_stream_payload(self, agent_id: str, run_id: str) -> str:
         run = self.get_run(agent_id, run_id)
-        data = json.dumps(run.model_dump(), indent=2)
+        data = json.dumps(run.model_dump(), separators=(',', ':'))
         return f'id: {run.id}:1\nevent: run.snapshot\ndata: {data}\n\n'
 
     def _replace_run(self, agent_id: str, updated: RunSummary) -> None:

--- a/api/app/services/run_service.py
+++ b/api/app/services/run_service.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import UTC, datetime
+from itertools import count
+from typing import DefaultDict
+
+from fastapi import HTTPException
+
+from app.models import RunCreateRequest, RunSummary
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).isoformat().replace('+00:00', 'Z')
+
+
+class RunService:
+    def __init__(self) -> None:
+        self._runs_by_agent: DefaultDict[str, list[RunSummary]] = defaultdict(list)
+        self._id_counter = count(1)
+
+    def create_run(self, agent_id: str, payload: RunCreateRequest) -> RunSummary:
+        run_id = f'run-{next(self._id_counter):04d}'
+        started_at = _iso_now()
+        run = RunSummary(
+            id=run_id,
+            agent_id=agent_id,
+            session_id=payload.session_id,
+            status='queued',
+            started_at=started_at,
+            ended_at=None,
+            current_model=None,
+            current_provider=None,
+            summary=payload.input,
+            stream_url=f'/api/agents/{agent_id}/runs/{run_id}/stream',
+            events_url=f'/api/agents/{agent_id}/runs/{run_id}/events',
+        )
+        self._runs_by_agent[agent_id].insert(0, run)
+        return run
+
+    def list_runs(self, agent_id: str) -> list[RunSummary]:
+        return list(self._runs_by_agent[agent_id])
+
+    def get_run(self, agent_id: str, run_id: str) -> RunSummary:
+        for run in self._runs_by_agent[agent_id]:
+            if run.id == run_id:
+                return run
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+
+    def stop_run(self, agent_id: str, run_id: str) -> RunSummary:
+        run = self.get_run(agent_id, run_id)
+        if run.status in {'completed', 'failed', 'stopped'}:
+            return run
+        updated = run.model_copy(update={'status': 'stopped', 'ended_at': _iso_now()})
+        self._replace_run(agent_id, updated)
+        return updated
+
+    def event_stream_payload(self, agent_id: str, run_id: str) -> str:
+        run = self.get_run(agent_id, run_id)
+        data = json.dumps(run.model_dump(), indent=2)
+        return f'id: {run.id}:1\nevent: run.snapshot\ndata: {data}\n\n'
+
+    def _replace_run(self, agent_id: str, updated: RunSummary) -> None:
+        self._runs_by_agent[agent_id] = [updated if run.id == updated.id else run for run in self._runs_by_agent[agent_id]]
+
+
+run_service = RunService()

--- a/api/tests/test_runs_api.py
+++ b/api/tests/test_runs_api.py
@@ -1,6 +1,17 @@
+import json
+
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.services.run_service import RunService
+
+
+@pytest.fixture(autouse=True)
+def isolated_run_service(monkeypatch) -> RunService:
+    service = RunService()
+    monkeypatch.setattr('app.main.run_service', service)
+    return service
 
 
 client = TestClient(app)
@@ -40,8 +51,8 @@ def test_run_lifecycle_endpoints_create_list_get_and_stop(monkeypatch) -> None:
 
     list_response = client.get('/api/agents/default/runs')
     assert list_response.status_code == 200
-    assert list_response.json()['total'] >= 1
-    assert any(run['id'] == run_id for run in list_response.json()['runs'])
+    assert list_response.json()['total'] == 1
+    assert [run['id'] for run in list_response.json()['runs']] == [run_id]
 
     detail_response = client.get(f'/api/agents/default/runs/{run_id}')
     assert detail_response.status_code == 200
@@ -74,5 +85,8 @@ def test_run_events_endpoint_exposes_sse_contract(monkeypatch) -> None:
     body = response.text
     assert 'event: run.snapshot' in body
     assert f'id: {run_id}:1' in body
-    assert '"status": "queued"' in body
-    assert '"agent_id": "default"' in body
+
+    data_lines = [line.removeprefix('data: ') for line in body.splitlines() if line.startswith('data: ')]
+    payload = json.loads('\n'.join(data_lines))
+    assert payload['status'] == 'queued'
+    assert payload['agent_id'] == 'default'

--- a/api/tests/test_runs_api.py
+++ b/api/tests/test_runs_api.py
@@ -1,0 +1,78 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_create_run_contract_returns_reconnectable_links(monkeypatch) -> None:
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.post(
+        '/api/agents/nightowl/runs',
+        json={
+            'session_id': 'sess-123',
+            'input': 'Summarize latest runtime health',
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload['agent_id'] == 'nightowl'
+    assert payload['session_id'] == 'sess-123'
+    assert payload['status'] == 'queued'
+    assert payload['summary'] == 'Summarize latest runtime health'
+    assert payload['stream_url'].endswith(f"/api/agents/nightowl/runs/{payload['id']}/stream")
+    assert payload['events_url'].endswith(f"/api/agents/nightowl/runs/{payload['id']}/events")
+    assert payload['started_at'] is not None
+    assert payload['ended_at'] is None
+
+
+def test_run_lifecycle_endpoints_create_list_get_and_stop(monkeypatch) -> None:
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    created = client.post(
+        '/api/agents/default/runs',
+        json={'session_id': 'sess-default', 'input': 'Check console'},
+    )
+    run_id = created.json()['id']
+
+    list_response = client.get('/api/agents/default/runs')
+    assert list_response.status_code == 200
+    assert list_response.json()['total'] >= 1
+    assert any(run['id'] == run_id for run in list_response.json()['runs'])
+
+    detail_response = client.get(f'/api/agents/default/runs/{run_id}')
+    assert detail_response.status_code == 200
+    assert detail_response.json()['id'] == run_id
+    assert detail_response.json()['status'] == 'queued'
+
+    stop_response = client.post(f'/api/agents/default/runs/{run_id}/stop')
+    assert stop_response.status_code == 200
+    assert stop_response.json()['status'] == 'stopped'
+    assert stop_response.json()['ended_at'] is not None
+
+    stopped_detail = client.get(f'/api/agents/default/runs/{run_id}')
+    assert stopped_detail.status_code == 200
+    assert stopped_detail.json()['status'] == 'stopped'
+
+
+def test_run_events_endpoint_exposes_sse_contract(monkeypatch) -> None:
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    created = client.post(
+        '/api/agents/default/runs',
+        json={'session_id': 'sess-stream', 'input': 'Stream hello'},
+    )
+    run_id = created.json()['id']
+
+    response = client.get(f'/api/agents/default/runs/{run_id}/events')
+
+    assert response.status_code == 200
+    assert response.headers['content-type'].startswith('text/event-stream')
+    body = response.text
+    assert 'event: run.snapshot' in body
+    assert f'id: {run_id}:1' in body
+    assert '"status": "queued"' in body
+    assert '"agent_id": "default"' in body

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { DashboardLayout } from './layouts/DashboardLayout'
+import { ConsolePage } from './pages/ConsolePage'
 import { CronJobsPage } from './pages/CronJobsPage'
 import { LogsPage } from './pages/LogsPage'
 import { OverviewPage } from './pages/OverviewPage'
@@ -13,6 +14,7 @@ function App() {
       <Route element={<DashboardLayout />}>
         <Route index element={<Navigate to="/overview" replace />} />
         <Route path="/overview" element={<OverviewPage />} />
+        <Route path="/console" element={<ConsolePage />} />
         <Route path="/profiles" element={<ProfilesPage />} />
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/sessions" element={<SessionsPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -238,20 +238,25 @@ const normalizeLogs = (payload: BackendLogsResponse): LogEntry[] =>
     message: line,
   }))
 
+const compareRunsByStartedAtDesc = (left: RunRecord, right: RunRecord): number =>
+  Date.parse(right.startedAt) - Date.parse(left.startedAt)
+
 const normalizeRuns = (payload: BackendRunsResponse): RunRecord[] =>
-  payload.runs.map((run) => ({
-    id: run.id,
-    profileId: run.agent_id,
-    sessionId: run.session_id ?? undefined,
-    status: run.status,
-    startedAt: run.started_at,
-    endedAt: run.ended_at ?? undefined,
-    model: run.current_model ?? 'Unassigned',
-    provider: run.current_provider ?? 'Unassigned',
-    summary: run.summary ?? 'No run summary available.',
-    streamUrl: run.stream_url,
-    eventsUrl: run.events_url,
-  }))
+  payload.runs
+    .map((run) => ({
+      id: run.id,
+      profileId: run.agent_id,
+      sessionId: run.session_id ?? undefined,
+      status: run.status,
+      startedAt: run.started_at,
+      endedAt: run.ended_at ?? undefined,
+      model: run.current_model ?? 'Unassigned',
+      provider: run.current_provider ?? 'Unassigned',
+      summary: run.summary ?? 'No run summary available.',
+      streamUrl: run.stream_url,
+      eventsUrl: run.events_url,
+    }))
+    .sort(compareRunsByStartedAtDesc)
 
 async function withFallback<T>(run: () => Promise<T>, fallback: () => T): Promise<ApiResult<T>> {
   try {
@@ -436,7 +441,11 @@ export const apiClient = {
     withFallback(async () => {
       const payload = await fetchJson<BackendRunsResponse>(`/agents/${encodeURIComponent(profileId)}/runs`)
       return normalizeRuns(payload)
-    }, () => structuredClone(mockRuns).filter((run) => run.profileId === profileId || profileId === 'default')),
+    }, () =>
+      structuredClone(mockRuns)
+        .filter((run) => run.profileId === profileId)
+        .sort(compareRunsByStartedAtDesc),
+    ),
 
   getCronJobs: async (): Promise<ApiResult<CronJob[]>> =>
     withFallback(async () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,6 +3,7 @@ import {
   mockLogs,
   mockOverview,
   mockProfiles,
+  mockRuns,
   mockSessions,
   mockSkills,
 } from './mockData'
@@ -13,6 +14,7 @@ import type {
   LogEntry,
   OverviewResponse,
   Profile,
+  RunRecord,
   SessionRecord,
   Skill,
   SkillBroadcastPayload,
@@ -101,6 +103,23 @@ type BackendLogsResponse = {
   path: string
   lines: string[]
   total_lines_returned: number
+}
+
+type BackendRunsResponse = {
+  runs: Array<{
+    id: string
+    agent_id: string
+    session_id?: string | null
+    status: 'queued' | 'running' | 'completed' | 'failed' | 'stopped'
+    started_at: string
+    ended_at?: string | null
+    current_model?: string | null
+    current_provider?: string | null
+    summary?: string | null
+    stream_url: string
+    events_url: string
+  }>
+  total: number
 }
 
 type BackendConfigSummary = {
@@ -217,6 +236,21 @@ const normalizeLogs = (payload: BackendLogsResponse): LogEntry[] =>
     level: inferLogLevel(line),
     source: payload.log_name,
     message: line,
+  }))
+
+const normalizeRuns = (payload: BackendRunsResponse): RunRecord[] =>
+  payload.runs.map((run) => ({
+    id: run.id,
+    profileId: run.agent_id,
+    sessionId: run.session_id ?? undefined,
+    status: run.status,
+    startedAt: run.started_at,
+    endedAt: run.ended_at ?? undefined,
+    model: run.current_model ?? 'Unassigned',
+    provider: run.current_provider ?? 'Unassigned',
+    summary: run.summary ?? 'No run summary available.',
+    streamUrl: run.stream_url,
+    eventsUrl: run.events_url,
   }))
 
 async function withFallback<T>(run: () => Promise<T>, fallback: () => T): Promise<ApiResult<T>> {
@@ -397,6 +431,12 @@ export const apiClient = {
       const payload = await fetchJson<BackendSessionsResponse>(`/sessions?profile=${encodeURIComponent(activeProfileId)}`)
       return normalizeSessions(payload)
     }, () => structuredClone(mockSessions)),
+
+  getRuns: async (profileId: string): Promise<ApiResult<RunRecord[]>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendRunsResponse>(`/agents/${encodeURIComponent(profileId)}/runs`)
+      return normalizeRuns(payload)
+    }, () => structuredClone(mockRuns).filter((run) => run.profileId === profileId || profileId === 'default')),
 
   getCronJobs: async (): Promise<ApiResult<CronJob[]>> =>
     withFallback(async () => {

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -3,6 +3,7 @@ import type {
   LogEntry,
   OverviewResponse,
   Profile,
+  RunRecord,
   SessionRecord,
   Skill,
 } from '../types'
@@ -149,6 +150,33 @@ export const mockSessions: SessionRecord[] = [
     startedAt: '2026-04-23T04:10:00Z',
     updatedAt: '2026-04-23T04:44:00Z',
     agent: 'Sandbox Runner',
+  },
+]
+
+export const mockRuns: RunRecord[] = [
+  {
+    id: 'run_2041',
+    profileId: 'default',
+    sessionId: 'sess_1421',
+    status: 'running',
+    startedAt: '2026-04-23T07:30:00Z',
+    model: 'gpt-5.4',
+    provider: 'custom',
+    summary: 'Validate dashboard adapter rollout and capture golden path.',
+    streamUrl: '/api/agents/default/runs/run_2041/stream',
+    eventsUrl: '/api/agents/default/runs/run_2041/events',
+  },
+  {
+    id: 'run_2040',
+    profileId: 'ops',
+    sessionId: 'sess_1420',
+    status: 'queued',
+    startedAt: '2026-04-23T07:20:00Z',
+    model: 'opus',
+    provider: 'airouter',
+    summary: 'Inspect gateway heartbeat jitter and summarize findings.',
+    streamUrl: '/api/agents/ops/runs/run_2040/stream',
+    eventsUrl: '/api/agents/ops/runs/run_2040/events',
   },
 ]
 

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -1,5 +1,6 @@
 import {
   ClockCircleOutlined,
+  ConsoleSqlOutlined,
   FileTextOutlined,
   ProfileOutlined,
   RadarChartOutlined,
@@ -19,6 +20,7 @@ const navigationItems: MenuProps['items'] = [
     label: 'Control',
     children: [
       { key: '/overview', label: 'Overview' },
+      { key: '/console', icon: <ConsoleSqlOutlined />, label: 'Console' },
       { key: '/sessions', icon: <RadarChartOutlined />, label: 'Sessions' },
       { key: '/cron-jobs', icon: <ClockCircleOutlined />, label: 'Cron Jobs' },
       { key: '/logs', icon: <FileTextOutlined />, label: 'Logs' },

--- a/web/src/pages/ConsolePage.tsx
+++ b/web/src/pages/ConsolePage.tsx
@@ -3,8 +3,9 @@ import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
 import { PageHeader } from '../components/PageHeader'
 import { useProfileStore } from '../store/profileStore'
+import type { RunRecord } from '../types'
 
-const statusColors: Record<string, string> = {
+const statusColors: Record<RunRecord['status'], string> = {
   queued: 'gold',
   running: 'blue',
   completed: 'green',
@@ -12,11 +13,20 @@ const statusColors: Record<string, string> = {
   stopped: 'default',
 }
 
+const getLatestRun = (runs: RunRecord[]): RunRecord | undefined =>
+  runs.reduce<RunRecord | undefined>((latest, run) => {
+    if (!latest) {
+      return run
+    }
+    return Date.parse(run.startedAt) > Date.parse(latest.startedAt) ? run : latest
+  }, undefined)
+
 export function ConsolePage() {
   const { selectedProfileId } = useProfileStore()
   const profileId = selectedProfileId ?? 'default'
   const { data, isLoading, isMock, error, refresh } = useApiQuery(() => apiClient.getRuns(profileId), [profileId])
   const runs = data ?? []
+  const latestRun = getLatestRun(runs)
 
   return (
     <div className="page-stack">
@@ -42,7 +52,7 @@ export function ConsolePage() {
                       title={
                         <Space wrap>
                           <Typography.Text strong>{run.id}</Typography.Text>
-                          <Tag color={statusColors[run.status] ?? 'default'}>{run.status}</Tag>
+                          <Tag color={statusColors[run.status]}>{run.status}</Tag>
                           <Typography.Text type="secondary">{run.provider} · {run.model}</Typography.Text>
                         </Space>
                       }
@@ -68,11 +78,11 @@ export function ConsolePage() {
             <Card className="glass-panel qwen-section-card" title="Stream contract">
               {isLoading ? (
                 <Skeleton active paragraph={{ rows: 3 }} title={false} />
-              ) : runs[0] ? (
+              ) : latestRun ? (
                 <Space direction="vertical" size={8} style={{ width: '100%' }}>
                   <Typography.Text strong>Latest run</Typography.Text>
-                  <Typography.Text code>{runs[0].streamUrl}</Typography.Text>
-                  <Typography.Text code>{runs[0].eventsUrl}</Typography.Text>
+                  <Typography.Text code>{latestRun.streamUrl}</Typography.Text>
+                  <Typography.Text code>{latestRun.eventsUrl}</Typography.Text>
                   <Typography.Text type="secondary">
                     SSE-first contract is live for reconnectable run snapshots while richer live console streaming lands in later slices.
                   </Typography.Text>

--- a/web/src/pages/ConsolePage.tsx
+++ b/web/src/pages/ConsolePage.tsx
@@ -1,0 +1,89 @@
+import { Card, Col, Empty, List, Row, Skeleton, Space, Tag, Typography } from 'antd'
+import { apiClient } from '../api/client'
+import { useApiQuery } from '../api/hooks'
+import { PageHeader } from '../components/PageHeader'
+import { useProfileStore } from '../store/profileStore'
+
+const statusColors: Record<string, string> = {
+  queued: 'gold',
+  running: 'blue',
+  completed: 'green',
+  failed: 'red',
+  stopped: 'default',
+}
+
+export function ConsolePage() {
+  const { selectedProfileId } = useProfileStore()
+  const profileId = selectedProfileId ?? 'default'
+  const { data, isLoading, isMock, error, refresh } = useApiQuery(() => apiClient.getRuns(profileId), [profileId])
+  const runs = data ?? []
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="Console"
+        description="Initial run lifecycle cockpit for queued and in-flight Hermes runs with reconnectable stream links."
+        mock={isMock}
+        error={error}
+        onRefresh={refresh}
+      />
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={16}>
+          <Card className="glass-panel qwen-section-card" title="Runs">
+            {isLoading ? (
+              <Skeleton active paragraph={{ rows: 5 }} title={false} />
+            ) : runs.length ? (
+              <List
+                dataSource={runs}
+                renderItem={(run) => (
+                  <List.Item className="qwen-list-item">
+                    <List.Item.Meta
+                      title={
+                        <Space wrap>
+                          <Typography.Text strong>{run.id}</Typography.Text>
+                          <Tag color={statusColors[run.status] ?? 'default'}>{run.status}</Tag>
+                          <Typography.Text type="secondary">{run.provider} · {run.model}</Typography.Text>
+                        </Space>
+                      }
+                      description={
+                        <Space direction="vertical" size={4}>
+                          <Typography.Text>{run.summary}</Typography.Text>
+                          <Typography.Text type="secondary">Session: {run.sessionId ?? 'unassigned'}</Typography.Text>
+                          <Typography.Text type="secondary">Started: {run.startedAt}</Typography.Text>
+                        </Space>
+                      }
+                    />
+                  </List.Item>
+                )}
+              />
+            ) : (
+              <Empty description="No runs yet for this profile." />
+            )}
+          </Card>
+        </Col>
+
+        <Col xs={24} xl={8}>
+          <Space direction="vertical" size={16} style={{ width: '100%' }}>
+            <Card className="glass-panel qwen-section-card" title="Stream contract">
+              {isLoading ? (
+                <Skeleton active paragraph={{ rows: 3 }} title={false} />
+              ) : runs[0] ? (
+                <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                  <Typography.Text strong>Latest run</Typography.Text>
+                  <Typography.Text code>{runs[0].streamUrl}</Typography.Text>
+                  <Typography.Text code>{runs[0].eventsUrl}</Typography.Text>
+                  <Typography.Text type="secondary">
+                    SSE-first contract is live for reconnectable run snapshots while richer live console streaming lands in later slices.
+                  </Typography.Text>
+                </Space>
+              ) : (
+                <Typography.Text type="secondary">Create a run through the API to see stream endpoints here.</Typography.Text>
+              )}
+            </Card>
+          </Space>
+        </Col>
+      </Row>
+    </div>
+  )
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -75,6 +75,20 @@ export interface SessionRecord {
   agent: string
 }
 
+export interface RunRecord {
+  id: string
+  profileId: string
+  sessionId?: string
+  status: 'queued' | 'running' | 'completed' | 'failed' | 'stopped'
+  startedAt: string
+  endedAt?: string
+  model: string
+  provider: string
+  summary: string
+  streamUrl: string
+  eventsUrl: string
+}
+
 export interface CronJob {
   id: string
   name: string


### PR DESCRIPTION
## Summary
- add run lifecycle contract endpoints for create/list/get/stop plus reconnectable SSE scaffolding
- add an in-memory run service to back the initial console/runs slice
- wire a minimal Console page to the new run contract with live/mock fallback

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_runs_api.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run build
- npm run lint

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runs API: create, list, retrieve, and stop agent runs with status tracking
  * Real-time SSE streaming endpoints to monitor run snapshots and events
  * Console page and navigation entry: view run history, details, stream/events URLs, and latest run summary
  * Client and mock data support for fetching and displaying runs

* **Tests**
  * End-to-end API tests for run lifecycle, SSE contract, and contract fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->