### PR TITLE
fix: preserve runtime registry adapter signature

### DIFF
--- a/api/app/services/runtime_registry.py
+++ b/api/app/services/runtime_registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Protocol
 
 from app.models import AgentRuntimeSummary, ProfileSummary, SessionSummary
 from app.services.hermes_adapter import (
@@ -15,11 +15,15 @@ from app.services.hermes_adapter import (
 from app.utils import load_yaml_file
 
 
+class ProfileSummaryProvider(Protocol):
+    def __call__(self, context: HermesContext, *, active_profile: str) -> ProfileSummary: ...
+
+
 @dataclass
 class RuntimeRegistry:
     contexts_provider: Callable[[], list[HermesContext]] = profile_contexts
     active_profile_provider: Callable[[], str] = active_profile_name
-    profile_summary_provider: Callable[[HermesContext, str], ProfileSummary] = profile_summary
+    profile_summary_provider: ProfileSummaryProvider = profile_summary
     session_reader: Callable[[str], list[SessionSummary]] = list_sessions
     active_run_counter: Callable[[str], int] | None = None
     mcp_status_provider: Callable[[str], str | None] | None = None
@@ -36,7 +40,7 @@ class RuntimeRegistry:
         context = next((item for item in self.contexts_provider() if item.profile == agent_id), None)
         if context is None:
             context = ensure_profile_exists(agent_id)
-        summary = self.profile_summary_provider(context, active_profile)
+        summary = self.profile_summary_provider(context, active_profile=active_profile)
         sessions = self.session_reader(agent_id)
         active_run_count = self._active_run_count(agent_id)
         last_activity = self._last_activity_at(sessions)

--- a/api/tests/test_runtime_registry.py
+++ b/api/tests/test_runtime_registry.py
@@ -24,6 +24,34 @@ def _profile_summary(*, name: str, is_active: bool, gateway_state: str | None, m
     )
 
 
+def test_runtime_registry_passes_active_profile_as_keyword_only_argument() -> None:
+    calls: list[tuple[str, str]] = []
+
+    def strict_profile_summary(context: HermesContext, *, active_profile: str) -> ProfileSummary:
+        calls.append((context.profile, active_profile))
+        return _profile_summary(
+            name=context.profile,
+            is_active=context.profile == active_profile,
+            gateway_state='online',
+            model='gpt-5.4',
+            provider='custom',
+        )
+
+    registry = RuntimeRegistry(
+        contexts_provider=lambda: [HermesContext(profile='default')],
+        active_profile_provider=lambda: 'default',
+        profile_summary_provider=strict_profile_summary,
+        session_reader=lambda profile: [],
+        active_run_counter=lambda profile: 0,
+        mcp_status_provider=lambda profile: 'idle',
+    )
+
+    runtime = registry.get_runtime('default')
+
+    assert runtime.agent_id == 'default'
+    assert calls == [('default', 'default')]
+
+
 def test_runtime_registry_builds_profile_scoped_capsule_summary() -> None:
     registry = RuntimeRegistry(
         contexts_provider=lambda: [HermesContext(profile='default'), HermesContext(profile='nightowl')],


### PR DESCRIPTION
## Summary
- reproduce the production `/api/agents/runtimes` regression with a failing keyword-only contract test
- pass `active_profile` through the runtime registry using the real adapter signature
- tighten the runtime registry provider typing so permissive stubs do not hide this bug again

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_runtime_registry.py::test_runtime_registry_passes_active_profile_as_keyword_only_argument -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run build
- npm run lint

Closes #21
