### PR TITLE
feat: add sessions search contracts

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -15,6 +15,7 @@ from app.models import (
     AgentRuntimeHints,
     AgentRuntimeSummary,
     AgentsResponse,
+    AgentSessionsResponse,
     AgentSummary,
     ConfigSummary,
     CreateProfileRequest,
@@ -23,6 +24,8 @@ from app.models import (
     RunCreateRequest,
     RunSummary,
     RunsResponse,
+    SessionDetail,
+    SessionSearchResponse,
     SkillBroadcastRequest,
     SkillBroadcastResult,
     SkillsResponse,
@@ -46,6 +49,7 @@ from app.services.hermes_adapter import (
 )
 from app.services.run_service import run_service
 from app.services.runtime_registry import runtime_registry
+from app.services.session_service import session_service
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
 
@@ -196,6 +200,24 @@ def post_profiles(payload: CreateProfileRequest) -> dict:
 @app.get('/api/sessions', tags=['sessions'])
 def get_sessions(profile: str = Query('default')) -> dict:
     return {'profile': profile, 'sessions': [item.model_dump() for item in list_sessions(profile)]}
+
+
+@app.get('/api/agents/{agent_id}/sessions/search', response_model=SessionSearchResponse, tags=['sessions'])
+def search_agent_sessions(agent_id: str, q: str = Query('')) -> SessionSearchResponse:
+    ensure_profile_exists(agent_id)
+    return session_service.search_sessions(agent_id, q)
+
+
+@app.get('/api/agents/{agent_id}/sessions', response_model=AgentSessionsResponse, tags=['sessions'])
+def list_agent_sessions(agent_id: str) -> AgentSessionsResponse:
+    ensure_profile_exists(agent_id)
+    return session_service.list_agent_sessions(agent_id)
+
+
+@app.get('/api/agents/{agent_id}/sessions/{session_id}', response_model=SessionDetail, tags=['sessions'])
+def get_agent_session(agent_id: str, session_id: str) -> SessionDetail:
+    ensure_profile_exists(agent_id)
+    return session_service.get_session(agent_id, session_id)
 
 
 @app.get('/api/skills', response_model=SkillsResponse, tags=['skills'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -144,6 +144,47 @@ class SessionSummary(BaseModel):
     last_active: str | None = None
 
 
+class SessionListItem(BaseModel):
+    id: str
+    title: str
+    status: Literal['running', 'queued', 'complete', 'failed'] = 'complete'
+    started_at: str | None = None
+    updated_at: str | None = None
+    source: str
+    searchable_excerpt: str | None = None
+    message_count: int = 0
+
+
+class SessionMessage(BaseModel):
+    role: str
+    content: str
+
+
+class SessionDetail(BaseModel):
+    id: str
+    agent_id: str
+    title: str
+    started_at: str | None = None
+    updated_at: str | None = None
+    source: str
+    searchable_excerpt: str | None = None
+    message_count: int = 0
+    messages: list[SessionMessage]
+
+
+class AgentSessionsResponse(BaseModel):
+    agent_id: str
+    sessions: list[SessionListItem]
+    total: int
+
+
+class SessionSearchResponse(BaseModel):
+    agent_id: str
+    query: str
+    sessions: list[SessionListItem]
+    total: int
+
+
 class SkillSummary(BaseModel):
     name: str
     category: str | None = None

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,0 +1,3 @@
+from . import session_service
+
+__all__ = ["session_service"]

--- a/api/app/services/session_service.py
+++ b/api/app/services/session_service.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from app.models import AgentSessionsResponse, SessionDetail, SessionListItem, SessionMessage, SessionSearchResponse, SessionSummary
+from app.services.hermes_adapter import ensure_profile_exists, list_sessions
+from app.utils import load_json_file
+
+
+class SessionService:
+    def __init__(self, summary_reader=list_sessions):
+        self.summary_reader = summary_reader
+
+    def list_agent_sessions(self, agent_id: str) -> AgentSessionsResponse:
+        context = ensure_profile_exists(agent_id)
+        sessions = sorted((self._session_list_item(agent_id, summary) for summary in self.summary_reader(agent_id)), key=self._sort_key, reverse=True)
+        return AgentSessionsResponse(agent_id=agent_id, sessions=sessions, total=len(sessions))
+
+    def get_session(self, agent_id: str, session_id: str) -> SessionDetail:
+        context = ensure_profile_exists(agent_id)
+        payload = self._load_session_payload(context.home, session_id)
+        if payload is None:
+            raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+        messages = self._extract_messages(payload)
+        title = payload.get('title') or payload.get('session_title') or session_id
+        source = payload.get('platform') or payload.get('model') or 'Filesystem session'
+        started_at = payload.get('session_start') or payload.get('started_at')
+        updated_at = payload.get('last_updated') or payload.get('updated_at') or started_at
+        searchable_excerpt = payload.get('platform') or payload.get('model') or source
+        message_count = payload.get('message_count') if isinstance(payload.get('message_count'), int) else len(messages)
+        return SessionDetail(
+            id=session_id,
+            agent_id=agent_id,
+            title=title,
+            started_at=started_at,
+            updated_at=updated_at,
+            source=source,
+            searchable_excerpt=searchable_excerpt,
+            message_count=message_count,
+            messages=messages,
+        )
+
+    def search_sessions(self, agent_id: str, query: str) -> SessionSearchResponse:
+        normalized_query = query.strip().lower()
+        sessions_response = self.list_agent_sessions(agent_id)
+        if not normalized_query:
+            return SessionSearchResponse(agent_id=agent_id, query=query, sessions=sessions_response.sessions, total=sessions_response.total)
+
+        matches: list[SessionListItem] = []
+        for session in sessions_response.sessions:
+            detail = self.get_session(agent_id, session.id)
+            haystack = ' '.join([
+                session.id,
+                session.title,
+                session.source,
+                session.searchable_excerpt or '',
+                ' '.join(message.content for message in detail.messages),
+            ]).lower()
+            if normalized_query in haystack:
+                matches.append(session)
+        return SessionSearchResponse(agent_id=agent_id, query=query, sessions=matches, total=len(matches))
+
+    def _session_list_item(self, agent_id: str, summary: SessionSummary) -> SessionListItem:
+        detail = self._try_get_session(agent_id, summary.id)
+        if detail is not None:
+            return SessionListItem(
+                id=detail.id,
+                title=detail.title,
+                status='complete',
+                started_at=detail.started_at,
+                updated_at=detail.updated_at,
+                source=detail.source,
+                searchable_excerpt=detail.searchable_excerpt,
+                message_count=detail.message_count,
+            )
+        return SessionListItem(
+            id=summary.id,
+            title=summary.title or summary.id,
+            status='complete',
+            started_at=summary.last_active,
+            updated_at=summary.last_active,
+            source=summary.preview or 'Hermes session',
+            searchable_excerpt=summary.preview,
+            message_count=0,
+        )
+
+    def _try_get_session(self, agent_id: str, session_id: str) -> SessionDetail | None:
+        try:
+            return self.get_session(agent_id, session_id)
+        except HTTPException as exc:
+            if exc.status_code == 404:
+                return None
+            raise
+
+    def _sort_key(self, session: SessionListItem) -> str:
+        return session.updated_at or session.started_at or ''
+
+    def _load_session_payload(self, home: Path, session_id: str) -> dict | None:
+        session_dir = home / 'sessions'
+        if not session_dir.exists():
+            return None
+
+        direct_candidates = [session_dir / f'{session_id}.json']
+        direct_candidates.extend(sorted(session_dir.glob(f'*{session_id}*.json')))
+        for path in direct_candidates:
+            payload = load_json_file(path)
+            if isinstance(payload, dict):
+                return payload
+
+        for path in sorted(session_dir.glob('*.json')):
+            payload = load_json_file(path)
+            if isinstance(payload, dict) and payload.get('session_id') == session_id:
+                return payload
+        return None
+
+    def _extract_messages(self, payload: dict) -> list[SessionMessage]:
+        raw_messages = payload.get('messages')
+        if not isinstance(raw_messages, list):
+            return []
+        messages: list[SessionMessage] = []
+        for item in raw_messages:
+            if not isinstance(item, dict):
+                continue
+            messages.append(SessionMessage(role=str(item.get('role') or 'assistant'), content=str(item.get('content') or '')))
+        return messages
+
+
+session_service = SessionService()

--- a/api/tests/test_sessions_api.py
+++ b/api/tests/test_sessions_api.py
@@ -1,0 +1,113 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models import SessionSummary
+
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def isolated_session_service(tmp_path, monkeypatch):
+    from app.services import session_service as session_service_module
+
+    session_dir = tmp_path / 'sessions'
+    session_dir.mkdir(parents=True)
+
+    def write_session(name: str, payload: dict) -> None:
+        (session_dir / name).write_text(json.dumps(payload), encoding='utf-8')
+
+    write_session(
+        'session_release.json',
+        {
+            'session_id': 'sess-release',
+            'title': 'Release readiness review',
+            'platform': 'discord',
+            'session_start': '2026-04-23T09:00:00Z',
+            'last_updated': '2026-04-23T09:30:00Z',
+            'message_count': 2,
+            'messages': [
+                {'role': 'user', 'content': 'Check release blockers'},
+                {'role': 'assistant', 'content': 'Two blockers remain'},
+            ],
+        },
+    )
+    write_session(
+        'session_incident.json',
+        {
+            'session_id': 'sess-incident',
+            'title': 'Incident triage',
+            'platform': 'telegram',
+            'session_start': '2026-04-23T08:00:00Z',
+            'last_updated': '2026-04-23T08:45:00Z',
+            'message_count': 1,
+            'messages': [
+                {'role': 'user', 'content': 'Gateway heartbeat jitter investigation'},
+            ],
+        },
+    )
+
+    monkeypatch.setattr(session_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    service = session_service_module.SessionService(
+        summary_reader=lambda agent_id: [
+            SessionSummary(
+                id='sess-incident',
+                title='Incident triage',
+                preview='telegram',
+                last_active='2026-04-23T08:45:00Z',
+            ),
+            SessionSummary(
+                id='sess-release',
+                title='Release readiness review',
+                preview='discord',
+                last_active='2026-04-23T09:30:00Z',
+            ),
+        ]
+    )
+    monkeypatch.setattr('app.main.session_service', service)
+
+    return service
+
+
+def test_agent_scoped_sessions_list_endpoint_returns_stable_contract(isolated_session_service) -> None:
+    response = client.get('/api/agents/default/sessions')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['total'] == 2
+    assert [session['id'] for session in payload['sessions']] == ['sess-release', 'sess-incident']
+    assert payload['sessions'][0]['title'] == 'Release readiness review'
+    assert payload['sessions'][0]['searchable_excerpt'] == 'discord'
+    assert payload['sessions'][0]['message_count'] == 2
+
+
+def test_agent_scoped_session_detail_endpoint_returns_transcript(isolated_session_service) -> None:
+    response = client.get('/api/agents/default/sessions/sess-release')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['id'] == 'sess-release'
+    assert payload['agent_id'] == 'default'
+    assert payload['title'] == 'Release readiness review'
+    assert payload['message_count'] == 2
+    assert payload['messages'][0] == {'role': 'user', 'content': 'Check release blockers'}
+    assert payload['messages'][1]['role'] == 'assistant'
+
+
+def test_agent_scoped_sessions_search_endpoint_filters_results(isolated_session_service) -> None:
+    response = client.get('/api/agents/default/sessions/search?q=incident')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['query'] == 'incident'
+    assert payload['total'] == 1
+    assert payload['sessions'][0]['id'] == 'sess-incident'
+    assert payload['sessions'][0]['title'] == 'Incident triage'

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -15,6 +15,7 @@ import type {
   OverviewResponse,
   Profile,
   RunRecord,
+  SessionDetailRecord,
   SessionRecord,
   Skill,
   SkillBroadcastPayload,
@@ -79,6 +80,36 @@ type BackendSessionsResponse = {
     title?: string | null
     preview?: string | null
     last_active?: string | null
+  }>
+}
+
+type BackendAgentSessionsResponse = {
+  agent_id: string
+  sessions: Array<{
+    id: string
+    title?: string | null
+    status?: 'running' | 'queued' | 'complete' | 'failed' | null
+    started_at?: string | null
+    updated_at?: string | null
+    source?: string | null
+    searchable_excerpt?: string | null
+    message_count?: number | null
+  }>
+  total: number
+}
+
+type BackendSessionDetailResponse = {
+  id: string
+  agent_id: string
+  title?: string | null
+  started_at?: string | null
+  updated_at?: string | null
+  source?: string | null
+  searchable_excerpt?: string | null
+  message_count?: number | null
+  messages: Array<{
+    role?: string | null
+    content?: string | null
   }>
 }
 
@@ -209,7 +240,37 @@ const normalizeSessions = (payload: BackendSessionsResponse): SessionRecord[] =>
     startedAt: session.last_active ?? isoNow(),
     updatedAt: session.last_active ?? isoNow(),
     agent: session.preview ?? 'Hermes session',
+    searchableExcerpt: session.preview ?? undefined,
+    messageCount: 0,
   }))
+
+const normalizeAgentSessions = (payload: BackendAgentSessionsResponse): SessionRecord[] =>
+  payload.sessions.map((session) => ({
+    id: session.id,
+    profileId: payload.agent_id,
+    title: session.title ?? session.id,
+    status: session.status ?? 'complete',
+    startedAt: session.started_at ?? session.updated_at ?? isoNow(),
+    updatedAt: session.updated_at ?? session.started_at ?? isoNow(),
+    agent: session.source ?? 'Hermes session',
+    searchableExcerpt: session.searchable_excerpt ?? undefined,
+    messageCount: session.message_count ?? 0,
+  }))
+
+const normalizeSessionDetail = (payload: BackendSessionDetailResponse): SessionDetailRecord => ({
+  id: payload.id,
+  profileId: payload.agent_id,
+  title: payload.title ?? payload.id,
+  startedAt: payload.started_at ?? payload.updated_at ?? isoNow(),
+  updatedAt: payload.updated_at ?? payload.started_at ?? isoNow(),
+  source: payload.source ?? 'Hermes session',
+  searchableExcerpt: payload.searchable_excerpt ?? undefined,
+  messageCount: payload.message_count ?? payload.messages.length,
+  messages: payload.messages.map((message) => ({
+    role: message.role ?? 'assistant',
+    content: message.content ?? '',
+  })),
+})
 
 const normalizeCronJobs = (payload: BackendCronJobsResponse): CronJob[] =>
   payload.jobs.map((job) => ({
@@ -436,6 +497,47 @@ export const apiClient = {
       const payload = await fetchJson<BackendSessionsResponse>(`/sessions?profile=${encodeURIComponent(activeProfileId)}`)
       return normalizeSessions(payload)
     }, () => structuredClone(mockSessions)),
+
+  getAgentSessions: async (profileId: string, query = ''): Promise<ApiResult<SessionRecord[]>> =>
+    withFallback(async () => {
+      const path = query.trim()
+        ? `/agents/${encodeURIComponent(profileId)}/sessions/search?q=${encodeURIComponent(query.trim())}`
+        : `/agents/${encodeURIComponent(profileId)}/sessions`
+      const payload = await fetchJson<BackendAgentSessionsResponse>(path)
+      return normalizeAgentSessions(payload)
+    }, () =>
+      structuredClone(mockSessions).filter((session) => {
+        if (session.profileId !== profileId) return false
+        if (!query.trim()) return true
+        const needle = query.trim().toLowerCase()
+        return [session.id, session.title, session.agent, session.searchableExcerpt ?? ''].join(' ').toLowerCase().includes(needle)
+      }),
+    ),
+
+  getAgentSession: async (profileId: string, sessionId: string): Promise<ApiResult<SessionDetailRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendSessionDetailResponse>(`/agents/${encodeURIComponent(profileId)}/sessions/${encodeURIComponent(sessionId)}`)
+      return normalizeSessionDetail(payload)
+    }, () => {
+      const session = structuredClone(mockSessions).find((item) => item.profileId === profileId && item.id === sessionId)
+      if (!session) {
+        throw new Error('Session not found')
+      }
+      return {
+        id: session.id,
+        profileId: session.profileId,
+        title: session.title,
+        startedAt: session.startedAt,
+        updatedAt: session.updatedAt,
+        source: session.agent,
+        searchableExcerpt: session.searchableExcerpt,
+        messageCount: session.messageCount,
+        messages: [
+          { role: 'user', content: `Open transcript for ${session.title}` },
+          { role: 'assistant', content: `${session.agent} is available as mocked transcript detail.` },
+        ],
+      }
+    }),
 
   getRuns: async (profileId: string): Promise<ApiResult<RunRecord[]>> =>
     withFallback(async () => {

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -132,6 +132,8 @@ export const mockSessions: SessionRecord[] = [
     startedAt: '2026-04-23T06:55:00Z',
     updatedAt: '2026-04-23T07:34:00Z',
     agent: 'Hermes Builder',
+    searchableExcerpt: 'Validate Dokploy deployment logs and dashboard golden path.',
+    messageCount: 14,
   },
   {
     id: 'sess_1420',
@@ -141,6 +143,8 @@ export const mockSessions: SessionRecord[] = [
     startedAt: '2026-04-23T06:40:00Z',
     updatedAt: '2026-04-23T07:21:00Z',
     agent: 'Ops Sentinel',
+    searchableExcerpt: 'Gateway heartbeat jitter investigation and retry-loop triage.',
+    messageCount: 9,
   },
   {
     id: 'sess_1418',
@@ -150,6 +154,8 @@ export const mockSessions: SessionRecord[] = [
     startedAt: '2026-04-23T04:10:00Z',
     updatedAt: '2026-04-23T04:44:00Z',
     agent: 'Sandbox Runner',
+    searchableExcerpt: 'Profile clone smoke test and bootstrap verification.',
+    messageCount: 6,
   },
 ]
 

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -1,9 +1,11 @@
-import { Card, Col, Row, Space, Table, Tag, Typography } from 'antd'
+import { useMemo, useState } from 'react'
+import { Card, Col, Input, Row, Space, Table, Tag, Typography } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
 import { PageHeader } from '../components/PageHeader'
-import type { SessionRecord } from '../types'
+import { useProfileStore } from '../store/profileStore'
+import type { ApiResult, SessionDetailRecord, SessionRecord } from '../types'
 
 const sessionStatusColor: Record<SessionRecord['status'], string> = {
   running: 'processing',
@@ -23,27 +25,62 @@ const columns: ColumnsType<SessionRecord> = [
       </Space>
     ),
   },
-  { title: 'Agent', dataIndex: 'agent' },
-  { title: 'Profile', dataIndex: 'profileId' },
+  {
+    title: 'Source',
+    dataIndex: 'agent',
+    render: (value: string, session) => (
+      <Space direction="vertical" size={2}>
+        <Typography.Text>{value}</Typography.Text>
+        <Typography.Text type="secondary">{session.searchableExcerpt ?? '—'}</Typography.Text>
+      </Space>
+    ),
+  },
+  { title: 'Messages', dataIndex: 'messageCount' },
   { title: 'Status', dataIndex: 'status', render: (value: SessionRecord['status']) => <Tag color={sessionStatusColor[value]}>{value}</Tag> },
-  { title: 'Started', dataIndex: 'startedAt', render: (value) => new Date(value).toLocaleString() },
-  { title: 'Updated', dataIndex: 'updatedAt', render: (value) => new Date(value).toLocaleString() },
+  { title: 'Updated', dataIndex: 'updatedAt', render: (value: string) => new Date(value).toLocaleString() },
 ]
 
 export function SessionsPage() {
-  const { data, isLoading, isMock, error, refresh } = useApiQuery(apiClient.getSessions, [])
-  const runningCount = (data ?? []).filter((session) => session.status === 'running').length
-  const queuedCount = (data ?? []).filter((session) => session.status === 'queued').length
-  const failedCount = (data ?? []).filter((session) => session.status === 'failed').length
+  const { selectedProfileId } = useProfileStore()
+  const profileId = selectedProfileId ?? 'default'
+  const [search, setSearch] = useState('')
+  const [selectedSessionId, setSelectedSessionId] = useState<string>()
+
+  const sessionsQuery = useApiQuery<SessionRecord[]>(() => apiClient.getAgentSessions(profileId, search), [profileId, search])
+  const sessions = useMemo<SessionRecord[]>(() => sessionsQuery.data ?? [], [sessionsQuery.data])
+  const effectiveSelectedSessionId = useMemo<string | undefined>(() => {
+    if (!sessions.length) return undefined
+    if (selectedSessionId && sessions.some((session) => session.id === selectedSessionId)) {
+      return selectedSessionId
+    }
+    return sessions[0].id
+  }, [selectedSessionId, sessions])
+
+  const detailQuery = useApiQuery<SessionDetailRecord | undefined>(
+    () =>
+      effectiveSelectedSessionId
+        ? apiClient.getAgentSession(profileId, effectiveSelectedSessionId)
+        : Promise.resolve<ApiResult<SessionDetailRecord | undefined>>({ data: undefined, mock: sessionsQuery.isMock }),
+    [effectiveSelectedSessionId, profileId, sessionsQuery.isMock],
+  )
+
+  const selectedSession = detailQuery.data
+  const runningCount = sessions.filter((session) => session.status === 'running').length
+  const queuedCount = sessions.filter((session) => session.status === 'queued').length
+  const failedCount = sessions.filter((session) => session.status === 'failed').length
+  const transcriptLines = useMemo(() => selectedSession?.messages ?? [], [selectedSession])
 
   return (
     <div className="page-stack">
       <PageHeader
         title="Sessions"
-        description="Inspect live and historical Hermes sessions across profiles with queue and completion state."
-        mock={isMock}
-        error={error}
-        onRefresh={refresh}
+        description="Inspect agent-scoped Hermes sessions with search, metadata, and transcript navigation."
+        mock={sessionsQuery.isMock || detailQuery.isMock}
+        error={sessionsQuery.error ?? detailQuery.error}
+        onRefresh={async () => {
+          await sessionsQuery.refresh()
+          await detailQuery.refresh()
+        }}
       />
 
       <Row gutter={[16, 16]}>
@@ -67,9 +104,56 @@ export function SessionsPage() {
         </Col>
       </Row>
 
-      <Card className="glass-panel qwen-section-card" title="Sessions explorer">
-        <Table rowKey="id" loading={isLoading} dataSource={data ?? []} columns={columns} pagination={false} />
-      </Card>
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={14}>
+          <Card
+            className="glass-panel qwen-section-card"
+            title="Sessions explorer"
+            extra={<Input.Search placeholder="Search sessions" allowClear value={search} onChange={(event) => setSearch(event.target.value)} style={{ width: 240 }} />}
+          >
+            <Table
+              rowKey="id"
+              loading={sessionsQuery.isLoading}
+              dataSource={sessions}
+              columns={columns}
+              pagination={false}
+              rowSelection={{
+                type: 'radio',
+                selectedRowKeys: effectiveSelectedSessionId ? [effectiveSelectedSessionId] : [],
+                onChange: (keys) => setSelectedSessionId(keys[0] as string),
+              }}
+              onRow={(record) => ({ onClick: () => setSelectedSessionId(record.id) })}
+            />
+          </Card>
+        </Col>
+
+        <Col xs={24} xl={10}>
+          <Card className="glass-panel qwen-section-card" title="Transcript viewer">
+            {selectedSession ? (
+              <Space direction="vertical" size={12} style={{ width: '100%' }}>
+                <div>
+                  <Typography.Text strong>{selectedSession.title}</Typography.Text>
+                  <br />
+                  <Typography.Text type="secondary">{selectedSession.id}</Typography.Text>
+                </div>
+                <Typography.Text type="secondary">
+                  {selectedSession.source} · {selectedSession.messageCount} messages · updated {new Date(selectedSession.updatedAt).toLocaleString()}
+                </Typography.Text>
+                <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                  {transcriptLines.map((message, index) => (
+                    <Card key={`${message.role}-${index}`} size="small">
+                      <Typography.Text strong>{message.role}</Typography.Text>
+                      <div style={{ whiteSpace: 'pre-wrap' }}>{message.content}</div>
+                    </Card>
+                  ))}
+                </Space>
+              </Space>
+            ) : (
+              <Typography.Text type="secondary">Select a session to inspect transcript details.</Typography.Text>
+            )}
+          </Card>
+        </Col>
+      </Row>
     </div>
   )
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -73,6 +73,25 @@ export interface SessionRecord {
   startedAt: string
   updatedAt: string
   agent: string
+  searchableExcerpt?: string
+  messageCount: number
+}
+
+export interface SessionMessageRecord {
+  role: string
+  content: string
+}
+
+export interface SessionDetailRecord {
+  id: string
+  profileId: string
+  title: string
+  startedAt: string
+  updatedAt: string
+  source: string
+  searchableExcerpt?: string
+  messageCount: number
+  messages: SessionMessageRecord[]
 }
 
 export interface RunRecord {


### PR DESCRIPTION
## Summary
- add stable agent-scoped sessions list/detail/search contracts and service adapter
- wire the dashboard Sessions page to agent-scoped APIs with search and transcript detail
- expand frontend session types and mock fallbacks to match the new contracts

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_sessions_api.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build

Closes #5
