### PR TITLE
feat: add agent config contracts

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -9,6 +9,9 @@ from fastapi.staticfiles import StaticFiles
 
 from app.core.settings import settings
 from app.models import (
+    AgentConfigPatchRequest,
+    AgentConfigReloadResponse,
+    AgentConfigResponse,
     AgentDefaults,
     AgentFiles,
     AgentRuntimeCollection,
@@ -47,6 +50,7 @@ from app.services.hermes_adapter import (
     profile_summary,
     status_payload,
 )
+from app.services.config_service import config_service
 from app.services.run_service import run_service
 from app.services.runtime_registry import runtime_registry
 from app.services.session_service import session_service
@@ -256,6 +260,24 @@ def get_logs(
     lines: int = Query(100, ge=1, le=500),
 ) -> LogEntry:
     return LogEntry(**log_payload(profile=profile, log_name=log_name, lines=lines))
+
+
+@app.get('/api/agents/{agent_id}/config', response_model=AgentConfigResponse, tags=['config'])
+def get_agent_config(agent_id: str) -> AgentConfigResponse:
+    ensure_profile_exists(agent_id)
+    return config_service.get_config(agent_id)
+
+
+@app.patch('/api/agents/{agent_id}/config', response_model=AgentConfigResponse, tags=['config'])
+def patch_agent_config(agent_id: str, payload: AgentConfigPatchRequest) -> AgentConfigResponse:
+    ensure_profile_exists(agent_id)
+    return config_service.patch_config(agent_id, payload.model_dump(exclude_none=True))
+
+
+@app.post('/api/agents/{agent_id}/config/reload', response_model=AgentConfigReloadResponse, tags=['config'])
+def reload_agent_config(agent_id: str) -> AgentConfigReloadResponse:
+    ensure_profile_exists(agent_id)
+    return config_service.reload_config(agent_id)
 
 
 @app.get('/api/config/summary', response_model=ConfigSummary, tags=['config'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -241,6 +241,35 @@ class ConfigSummary(BaseModel):
     summary: dict[str, Any]
 
 
+class RuntimeToggles(BaseModel):
+    checkpoints_enabled: bool = False
+    worktree_enabled: bool = False
+
+
+class AgentConfigResponse(BaseModel):
+    agent_id: str
+    path: str
+    effective_config: dict[str, Any]
+    profile_overrides: dict[str, Any]
+    runtime_toggles: RuntimeToggles
+    editable_fields: list[str]
+    deferred_fields: list[str]
+    write_restrictions: list[str]
+
+
+class AgentConfigPatchRequest(BaseModel):
+    model: dict[str, Any] | None = None
+    display: dict[str, Any] | None = None
+    runtime: dict[str, Any] | None = None
+
+
+class AgentConfigReloadResponse(BaseModel):
+    agent_id: str
+    path: str
+    reloaded: bool
+    message: str
+
+
 class StatusResponse(BaseModel):
     ok: bool
     active_profile: str

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import session_service
+from . import config_service, session_service
 
-__all__ = ["session_service"]
+__all__ = ["config_service", "session_service"]

--- a/api/app/services/config_service.py
+++ b/api/app/services/config_service.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.models import AgentConfigReloadResponse, AgentConfigResponse, RuntimeToggles
+from app.services.hermes_adapter import ensure_profile_exists
+from app.utils import load_yaml_file, redact_secrets
+
+EDITABLE_FIELDS = [
+    'display.personality',
+    'model.default',
+    'model.provider',
+    'runtime.checkpoints_enabled',
+    'runtime.worktree_enabled',
+]
+DEFERRED_FIELDS = ['providers', 'fallback_providers']
+WRITE_RESTRICTIONS = [
+    'Provider credentials and fallback chains remain read-only in Config v1.',
+    'Only display.personality, model.default/provider, and runtime toggles are writable in this slice.',
+]
+
+
+class ConfigService:
+    def get_config(self, agent_id: str) -> AgentConfigResponse:
+        context = ensure_profile_exists(agent_id)
+        config_path = context.home / 'config.yaml'
+        config = load_yaml_file(config_path)
+        return self._response(agent_id, config_path, config)
+
+    def patch_config(self, agent_id: str, payload: dict[str, Any]) -> AgentConfigResponse:
+        context = ensure_profile_exists(agent_id)
+        config_path = context.home / 'config.yaml'
+        config = load_yaml_file(config_path)
+
+        if isinstance(payload.get('display'), dict):
+            config.setdefault('display', {})
+            personality = payload['display'].get('personality')
+            if personality is not None:
+                config['display']['personality'] = personality
+
+        if isinstance(payload.get('model'), dict):
+            config.setdefault('model', {})
+            for key in ['default', 'provider']:
+                if payload['model'].get(key) is not None:
+                    config['model'][key] = payload['model'][key]
+
+        if isinstance(payload.get('runtime'), dict):
+            config.setdefault('runtime', {})
+            for key in ['checkpoints_enabled', 'worktree_enabled']:
+                if key in payload['runtime']:
+                    config['runtime'][key] = bool(payload['runtime'][key])
+
+        config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding='utf-8')
+        return self._response(agent_id, config_path, config)
+
+    def reload_config(self, agent_id: str) -> AgentConfigReloadResponse:
+        context = ensure_profile_exists(agent_id)
+        config_path = context.home / 'config.yaml'
+        return AgentConfigReloadResponse(
+            agent_id=agent_id,
+            path=str(config_path),
+            reloaded=True,
+            message='Config reload requested',
+        )
+
+    def _response(self, agent_id: str, config_path: Path, config: dict[str, Any]) -> AgentConfigResponse:
+        runtime = config.get('runtime') if isinstance(config.get('runtime'), dict) else {}
+        return AgentConfigResponse(
+            agent_id=agent_id,
+            path=str(config_path),
+            effective_config=redact_secrets(config),
+            profile_overrides=redact_secrets(config),
+            runtime_toggles=RuntimeToggles(
+                checkpoints_enabled=bool(runtime.get('checkpoints_enabled', False)),
+                worktree_enabled=bool(runtime.get('worktree_enabled', False)),
+            ),
+            editable_fields=EDITABLE_FIELDS,
+            deferred_fields=DEFERRED_FIELDS,
+            write_restrictions=WRITE_RESTRICTIONS,
+        )
+
+
+config_service = ConfigService()

--- a/api/tests/test_agent_config_api.py
+++ b/api/tests/test_agent_config_api.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def write_config(path: Path, payload: dict) -> None:
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
+
+
+def test_agent_config_endpoint_returns_redacted_effective_config(tmp_path, monkeypatch) -> None:
+    from app.services import config_service as config_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'model': {'default': 'gpt-5.4', 'provider': 'custom'},
+            'display': {'personality': 'creative'},
+            'providers': {'custom': {'api_key': 'super-secret', 'base_url': 'https://example.com'}},
+            'runtime': {'checkpoints_enabled': True, 'worktree_enabled': False},
+            'fallback_providers': ['backup-a'],
+        },
+    )
+
+    monkeypatch.setattr(config_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.get('/api/agents/default/config')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['path'] == str(config_path)
+    assert payload['effective_config']['providers']['custom']['api_key'] == '***redacted***'
+    assert payload['effective_config']['display']['personality'] == 'creative'
+    assert payload['runtime_toggles'] == {'checkpoints_enabled': True, 'worktree_enabled': False}
+    assert 'providers' in payload['deferred_fields']
+    assert 'fallback_providers' in payload['deferred_fields']
+
+
+def test_agent_config_patch_updates_allowed_fields_only(tmp_path, monkeypatch) -> None:
+    from app.services import config_service as config_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'model': {'default': 'gpt-5.4', 'provider': 'custom'},
+            'display': {'personality': 'creative'},
+            'providers': {'custom': {'api_key': 'super-secret', 'base_url': 'https://example.com'}},
+            'runtime': {'checkpoints_enabled': True, 'worktree_enabled': False},
+        },
+    )
+
+    monkeypatch.setattr(config_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.patch(
+        '/api/agents/default/config',
+        json={
+            'display': {'personality': 'focused'},
+            'model': {'default': 'gpt-5.5', 'provider': 'custom'},
+            'runtime': {'checkpoints_enabled': False, 'worktree_enabled': True},
+            'providers': {'custom': {'api_key': 'should-not-overwrite'}},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['effective_config']['display']['personality'] == 'focused'
+    assert payload['effective_config']['model']['default'] == 'gpt-5.5'
+    assert payload['runtime_toggles'] == {'checkpoints_enabled': False, 'worktree_enabled': True}
+
+    stored = yaml.safe_load(config_path.read_text(encoding='utf-8'))
+    assert stored['display']['personality'] == 'focused'
+    assert stored['model']['default'] == 'gpt-5.5'
+    assert stored['runtime']['checkpoints_enabled'] is False
+    assert stored['runtime']['worktree_enabled'] is True
+    assert stored['providers']['custom']['api_key'] == 'super-secret'
+
+
+def test_agent_config_reload_endpoint_returns_reload_status(tmp_path, monkeypatch) -> None:
+    from app.services import config_service as config_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(config_path, {'display': {'personality': 'creative'}})
+
+    monkeypatch.setattr(config_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.post('/api/agents/default/config/reload')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        'agent_id': 'default',
+        'path': str(config_path),
+        'reloaded': True,
+        'message': 'Config reload requested',
+    }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { DashboardLayout } from './layouts/DashboardLayout'
+import { ConfigPage } from './pages/ConfigPage'
 import { ConsolePage } from './pages/ConsolePage'
 import { CronJobsPage } from './pages/CronJobsPage'
 import { LogsPage } from './pages/LogsPage'
@@ -18,6 +19,7 @@ function App() {
         <Route path="/profiles" element={<ProfilesPage />} />
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/sessions" element={<SessionsPage />} />
+        <Route path="/config" element={<ConfigPage />} />
         <Route path="/cron-jobs" element={<CronJobsPage />} />
         <Route path="/logs" element={<LogsPage />} />
       </Route>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,4 +1,5 @@
 import {
+  mockAgentConfig,
   mockCronJobs,
   mockLogs,
   mockOverview,
@@ -8,6 +9,7 @@ import {
   mockSkills,
 } from './mockData'
 import type {
+  AgentConfigRecord,
   ApiResult,
   CreateProfilePayload,
   CronJob,
@@ -158,6 +160,20 @@ type BackendConfigSummary = {
   path: string
   keys: string[]
   summary: Record<string, unknown>
+}
+
+type BackendAgentConfigResponse = {
+  agent_id: string
+  path: string
+  effective_config: Record<string, unknown>
+  profile_overrides: Record<string, unknown>
+  runtime_toggles: {
+    checkpoints_enabled: boolean
+    worktree_enabled: boolean
+  }
+  editable_fields: string[]
+  deferred_fields: string[]
+  write_restrictions: string[]
 }
 
 type BackendCreateProfileResponse = {
@@ -318,6 +334,20 @@ const normalizeRuns = (payload: BackendRunsResponse): RunRecord[] =>
       eventsUrl: run.events_url,
     }))
     .sort(compareRunsByStartedAtDesc)
+
+const normalizeAgentConfig = (payload: BackendAgentConfigResponse): AgentConfigRecord => ({
+  agentId: payload.agent_id,
+  path: payload.path,
+  effectiveConfig: payload.effective_config,
+  profileOverrides: payload.profile_overrides,
+  runtimeToggles: {
+    checkpointsEnabled: payload.runtime_toggles.checkpoints_enabled,
+    worktreeEnabled: payload.runtime_toggles.worktree_enabled,
+  },
+  editableFields: payload.editable_fields,
+  deferredFields: payload.deferred_fields,
+  writeRestrictions: payload.write_restrictions,
+})
 
 async function withFallback<T>(run: () => Promise<T>, fallback: () => T): Promise<ApiResult<T>> {
   try {
@@ -575,5 +605,15 @@ export const apiClient = {
       path: '/opt/data/config.yaml',
       keys: [],
       summary: {},
+    })),
+
+  getAgentConfig: async (profileId: string): Promise<ApiResult<AgentConfigRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendAgentConfigResponse>(`/agents/${encodeURIComponent(profileId)}/config`)
+      return normalizeAgentConfig(payload)
+    }, () => ({
+      ...structuredClone(mockAgentConfig),
+      agentId: profileId,
+      path: `/opt/data/hermes/profiles/${profileId}/config.yaml`,
     })),
 }

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentConfigRecord,
   CronJob,
   LogEntry,
   OverviewResponse,
@@ -215,6 +216,33 @@ export const mockCronJobs: CronJob[] = [
     nextRun: '2026-04-23T12:00:00Z',
   },
 ]
+
+export const mockAgentConfig: AgentConfigRecord = {
+  agentId: 'default',
+  path: '/opt/data/hermes/profiles/default/config.yaml',
+  effectiveConfig: {
+    display: { personality: 'creative' },
+    model: { default: 'gpt-5.4', provider: 'custom' },
+    providers: { custom: { api_key: '***redacted***', base_url: 'https://providers.gnoviawan.com/v1' } },
+    runtime: { checkpoints_enabled: true, worktree_enabled: false },
+    fallback_providers: ['glm-5.1', 'glm-5'],
+  },
+  profileOverrides: {
+    display: { personality: 'creative' },
+    model: { default: 'gpt-5.4', provider: 'custom' },
+    runtime: { checkpoints_enabled: true, worktree_enabled: false },
+  },
+  runtimeToggles: {
+    checkpointsEnabled: true,
+    worktreeEnabled: false,
+  },
+  editableFields: ['display.personality', 'model.default', 'model.provider', 'runtime.checkpoints_enabled', 'runtime.worktree_enabled'],
+  deferredFields: ['providers', 'fallback_providers'],
+  writeRestrictions: [
+    'Provider credentials and fallback chains remain read-only in Config v1.',
+    'Only personality, model selection, and runtime toggles are writable in this slice.',
+  ],
+}
 
 export const mockLogs: LogEntry[] = [
   {

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -4,6 +4,7 @@ import {
   FileTextOutlined,
   ProfileOutlined,
   RadarChartOutlined,
+  SettingOutlined,
   ToolOutlined,
 } from '@ant-design/icons'
 import { Layout, Menu, Select, Space, Tag, Typography } from 'antd'
@@ -31,6 +32,7 @@ const navigationItems: MenuProps['items'] = [
     label: 'Settings',
     children: [
       { key: '/profiles', icon: <ProfileOutlined />, label: 'Profiles' },
+      { key: '/config', icon: <SettingOutlined />, label: 'Config' },
       { key: '/skills', icon: <ToolOutlined />, label: 'Skills' },
     ],
   },

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -1,0 +1,91 @@
+import { Card, Col, List, Row, Space, Switch, Tag, Typography } from 'antd'
+import { apiClient } from '../api/client'
+import { useApiQuery } from '../api/hooks'
+import { PageHeader } from '../components/PageHeader'
+import { useProfileStore } from '../store/profileStore'
+import type { AgentConfigRecord } from '../types'
+
+export function ConfigPage() {
+  const { selectedProfileId } = useProfileStore()
+  const profileId = selectedProfileId ?? 'default'
+  const { data, isLoading, isMock, error, refresh } = useApiQuery<AgentConfigRecord>(() => apiClient.getAgentConfig(profileId), [profileId])
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="Config"
+        description="Inspect effective config, profile overrides, runtime toggles, and write restrictions for the active Hermes profile."
+        mock={isMock}
+        error={error}
+        onRefresh={refresh}
+      />
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card" loading={isLoading}>
+            <span className="qwen-summary-label">Profile</span>
+            <Typography.Title level={3}>{data?.agentId ?? profileId}</Typography.Title>
+            <Typography.Text type="secondary">{data?.path ?? 'Config path unavailable'}</Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card" loading={isLoading}>
+            <span className="qwen-summary-label">Checkpoints</span>
+            <Typography.Title level={3}>{data?.runtimeToggles.checkpointsEnabled ? 'On' : 'Off'}</Typography.Title>
+            <Switch checked={data?.runtimeToggles.checkpointsEnabled} disabled />
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card" loading={isLoading}>
+            <span className="qwen-summary-label">Worktree</span>
+            <Typography.Title level={3}>{data?.runtimeToggles.worktreeEnabled ? 'On' : 'Off'}</Typography.Title>
+            <Switch checked={data?.runtimeToggles.worktreeEnabled} disabled />
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={12}>
+          <Card className="glass-panel qwen-section-card" title="Effective config" loading={isLoading}>
+            <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{JSON.stringify(data?.effectiveConfig ?? {}, null, 2)}</pre>
+          </Card>
+        </Col>
+        <Col xs={24} xl={12}>
+          <Card className="glass-panel qwen-section-card" title="Profile overrides" loading={isLoading}>
+            <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{JSON.stringify(data?.profileOverrides ?? {}, null, 2)}</pre>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={8}>
+          <Card className="glass-panel qwen-section-card" title="Editable fields" loading={isLoading}>
+            <Space wrap>
+              {(data?.editableFields ?? []).map((field) => (
+                <Tag key={field} color="blue">{field}</Tag>
+              ))}
+            </Space>
+          </Card>
+        </Col>
+        <Col xs={24} xl={8}>
+          <Card className="glass-panel qwen-section-card" title="Deferred fields" loading={isLoading}>
+            <Space wrap>
+              {(data?.deferredFields ?? []).map((field) => (
+                <Tag key={field} color="gold">{field}</Tag>
+              ))}
+            </Space>
+          </Card>
+        </Col>
+        <Col xs={24} xl={8}>
+          <Card className="glass-panel qwen-section-card" title="Write restrictions" loading={isLoading}>
+            <List
+              size="small"
+              dataSource={data?.writeRestrictions ?? []}
+              renderItem={(item) => <List.Item>{item}</List.Item>}
+            />
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  )
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -118,6 +118,20 @@ export interface CronJob {
   nextRun: string
 }
 
+export interface AgentConfigRecord {
+  agentId: string
+  path: string
+  effectiveConfig: Record<string, unknown>
+  profileOverrides: Record<string, unknown>
+  runtimeToggles: {
+    checkpointsEnabled: boolean
+    worktreeEnabled: boolean
+  }
+  editableFields: string[]
+  deferredFields: string[]
+  writeRestrictions: string[]
+}
+
 export interface LogEntry {
   id: string
   timestamp: string


### PR DESCRIPTION
## Summary
- add stable agent-scoped config read/update/reload contracts plus a dedicated config service
- redact sensitive config values while exposing editable fields, deferred fields, and runtime toggles
- wire a Config page to the new agent-scoped endpoint with profile-aware fallback data

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_agent_config_api.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build

Closes #6
