### PR TITLE
feat: add provider catalog contracts

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -24,6 +24,10 @@ from app.models import (
     CreateProfileRequest,
     HealthResponse,
     LogEntry,
+    ModelCatalogResponse,
+    ProviderCatalogResponse,
+    ProviderRoutingPatchRequest,
+    ProviderRoutingResponse,
     RunCreateRequest,
     RunSummary,
     RunsResponse,
@@ -51,6 +55,7 @@ from app.services.hermes_adapter import (
     status_payload,
 )
 from app.services.config_service import config_service
+from app.services.provider_service import provider_service
 from app.services.run_service import run_service
 from app.services.runtime_registry import runtime_registry
 from app.services.session_service import session_service
@@ -113,6 +118,26 @@ def get_system_version() -> SystemVersionResponse:
         api_version=settings.dashboard_api_version,
         app_version=settings.app_version,
     )
+
+
+@app.get('/api/system/providers', response_model=ProviderCatalogResponse, tags=['system'])
+def get_system_providers() -> ProviderCatalogResponse:
+    return provider_service.list_providers()
+
+
+@app.get('/api/system/models', response_model=ModelCatalogResponse, tags=['system'])
+def get_system_models() -> ModelCatalogResponse:
+    return provider_service.list_models()
+
+
+@app.get('/api/system/provider-routing', response_model=ProviderRoutingResponse, tags=['system'])
+def get_system_provider_routing() -> ProviderRoutingResponse:
+    return provider_service.get_routing()
+
+
+@app.patch('/api/system/provider-routing', response_model=ProviderRoutingResponse, tags=['system'])
+def patch_system_provider_routing(payload: ProviderRoutingPatchRequest) -> ProviderRoutingResponse:
+    return provider_service.patch_routing(payload.model_dump(exclude_none=True))
 
 
 @app.get('/api/status', response_model=StatusResponse, tags=['system'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -270,6 +270,45 @@ class AgentConfigReloadResponse(BaseModel):
     message: str
 
 
+class ProviderCatalogItem(BaseModel):
+    name: str
+    config: dict[str, Any]
+    has_credentials: bool = False
+    source: str = 'config'
+
+
+class ProviderCatalogResponse(BaseModel):
+    providers: list[ProviderCatalogItem]
+    total: int
+
+
+class ModelCatalogItem(BaseModel):
+    id: str
+    provider: str
+    source: str = 'config'
+
+
+class ModelCatalogResponse(BaseModel):
+    models: list[ModelCatalogItem]
+    total: int
+    default_model: str | None = None
+    default_provider: str | None = None
+
+
+class ProviderRoutingResponse(BaseModel):
+    default_provider: str | None = None
+    default_model: str | None = None
+    fallback_providers: list[str]
+    effective_provider_count: int = 0
+    write_restrictions: list[str]
+
+
+class ProviderRoutingPatchRequest(BaseModel):
+    default_provider: str | None = None
+    default_model: str | None = None
+    fallback_providers: list[str] | None = None
+
+
 class StatusResponse(BaseModel):
     ok: bool
     active_profile: str

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import config_service, session_service
+from . import config_service, provider_service, session_service
 
-__all__ = ["config_service", "session_service"]
+__all__ = ["config_service", "provider_service", "session_service"]

--- a/api/app/services/provider_service.py
+++ b/api/app/services/provider_service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+from tempfile import NamedTemporaryFile
+from threading import RLock
 from typing import Any
 
 import yaml
@@ -16,6 +18,7 @@ from app.services.hermes_adapter import ensure_profile_exists
 from app.utils import load_yaml_file, redact_secrets
 
 WRITE_RESTRICTIONS = ['Provider credentials remain redacted in provider routing views.']
+_WRITE_LOCK = RLock()
 
 
 class ProviderService:
@@ -44,18 +47,27 @@ class ProviderService:
         model_cfg = config.get('model') if isinstance(config.get('model'), dict) else {}
         model_map = config.get('models') if isinstance(config.get('models'), dict) else {}
         items: list[ModelCatalogItem] = []
+        seen: set[tuple[str, str]] = set()
         for provider_name, models in sorted(model_map.items()):
             if isinstance(models, list):
                 for model in models:
+                    entry = (provider_name, str(model))
+                    if entry in seen:
+                        continue
+                    seen.add(entry)
                     items.append(ModelCatalogItem(id=str(model), provider=provider_name))
-        if not items and model_cfg.get('default') and model_cfg.get('provider'):
-            items.append(ModelCatalogItem(id=str(model_cfg['default']), provider=str(model_cfg['provider'])))
+        default_model = model_cfg.get('default')
+        default_provider = model_cfg.get('provider')
+        if default_model and default_provider:
+            default_entry = (str(default_provider), str(default_model))
+            if default_entry not in seen:
+                items.append(ModelCatalogItem(id=str(default_model), provider=str(default_provider)))
         items.sort(key=lambda item: (item.provider, item.id))
         return ModelCatalogResponse(
             models=items,
             total=len(items),
-            default_model=model_cfg.get('default'),
-            default_provider=model_cfg.get('provider'),
+            default_model=default_model,
+            default_provider=default_provider,
         )
 
     def get_routing(self) -> ProviderRoutingResponse:
@@ -74,16 +86,25 @@ class ProviderService:
 
     def patch_routing(self, payload: dict[str, Any]) -> ProviderRoutingResponse:
         config_path = self._config_path()
-        config = self._config()
-        config.setdefault('model', {})
-        if payload.get('default_provider') is not None:
-            config['model']['provider'] = payload['default_provider']
-        if payload.get('default_model') is not None:
-            config['model']['default'] = payload['default_model']
-        if payload.get('fallback_providers') is not None:
-            config['fallback_providers'] = [str(provider) for provider in payload['fallback_providers']]
-        config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding='utf-8')
+        with _WRITE_LOCK:
+            config = load_yaml_file(config_path)
+            model_cfg = config.get('model') if isinstance(config.get('model'), dict) else {}
+            config['model'] = dict(model_cfg)
+            if payload.get('default_provider') is not None:
+                config['model']['provider'] = payload['default_provider']
+            if payload.get('default_model') is not None:
+                config['model']['default'] = payload['default_model']
+            if payload.get('fallback_providers') is not None:
+                config['fallback_providers'] = [str(provider) for provider in payload['fallback_providers']]
+            self._atomic_write_yaml(config_path, config)
         return self.get_routing()
+
+    def _atomic_write_yaml(self, path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile('w', encoding='utf-8', dir=path.parent, delete=False) as handle:
+            yaml.safe_dump(payload, handle, sort_keys=False)
+            temp_path = Path(handle.name)
+        temp_path.replace(path)
 
     def _has_credentials(self, provider_cfg: Any) -> bool:
         return isinstance(provider_cfg, dict) and any(key.lower() in {'api_key', 'token', 'password', 'secret', 'authorization'} for key in provider_cfg.keys())

--- a/api/app/services/provider_service.py
+++ b/api/app/services/provider_service.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.models import (
+    ModelCatalogItem,
+    ModelCatalogResponse,
+    ProviderCatalogItem,
+    ProviderCatalogResponse,
+    ProviderRoutingResponse,
+)
+from app.services.hermes_adapter import ensure_profile_exists
+from app.utils import load_yaml_file, redact_secrets
+
+WRITE_RESTRICTIONS = ['Provider credentials remain redacted in provider routing views.']
+
+
+class ProviderService:
+    def _config_path(self) -> Path:
+        context = ensure_profile_exists('default')
+        return context.home / 'config.yaml'
+
+    def _config(self) -> dict[str, Any]:
+        return load_yaml_file(self._config_path())
+
+    def list_providers(self) -> ProviderCatalogResponse:
+        config = self._config()
+        providers = config.get('providers') if isinstance(config.get('providers'), dict) else {}
+        items = [
+            ProviderCatalogItem(
+                name=name,
+                config=redact_secrets(provider_cfg if isinstance(provider_cfg, dict) else {}),
+                has_credentials=self._has_credentials(provider_cfg),
+            )
+            for name, provider_cfg in sorted(providers.items())
+        ]
+        return ProviderCatalogResponse(providers=items, total=len(items))
+
+    def list_models(self) -> ModelCatalogResponse:
+        config = self._config()
+        model_cfg = config.get('model') if isinstance(config.get('model'), dict) else {}
+        model_map = config.get('models') if isinstance(config.get('models'), dict) else {}
+        items: list[ModelCatalogItem] = []
+        for provider_name, models in sorted(model_map.items()):
+            if isinstance(models, list):
+                for model in models:
+                    items.append(ModelCatalogItem(id=str(model), provider=provider_name))
+        if not items and model_cfg.get('default') and model_cfg.get('provider'):
+            items.append(ModelCatalogItem(id=str(model_cfg['default']), provider=str(model_cfg['provider'])))
+        items.sort(key=lambda item: (item.provider, item.id))
+        return ModelCatalogResponse(
+            models=items,
+            total=len(items),
+            default_model=model_cfg.get('default'),
+            default_provider=model_cfg.get('provider'),
+        )
+
+    def get_routing(self) -> ProviderRoutingResponse:
+        config = self._config()
+        model_cfg = config.get('model') if isinstance(config.get('model'), dict) else {}
+        fallback_providers = config.get('fallback_providers') if isinstance(config.get('fallback_providers'), list) else []
+        default_provider = model_cfg.get('provider')
+        unique_providers = {provider for provider in [default_provider, *fallback_providers] if provider}
+        return ProviderRoutingResponse(
+            default_provider=default_provider,
+            default_model=model_cfg.get('default'),
+            fallback_providers=[str(provider) for provider in fallback_providers],
+            effective_provider_count=len(unique_providers),
+            write_restrictions=WRITE_RESTRICTIONS,
+        )
+
+    def patch_routing(self, payload: dict[str, Any]) -> ProviderRoutingResponse:
+        config_path = self._config_path()
+        config = self._config()
+        config.setdefault('model', {})
+        if payload.get('default_provider') is not None:
+            config['model']['provider'] = payload['default_provider']
+        if payload.get('default_model') is not None:
+            config['model']['default'] = payload['default_model']
+        if payload.get('fallback_providers') is not None:
+            config['fallback_providers'] = [str(provider) for provider in payload['fallback_providers']]
+        config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding='utf-8')
+        return self.get_routing()
+
+    def _has_credentials(self, provider_cfg: Any) -> bool:
+        return isinstance(provider_cfg, dict) and any(key.lower() in {'api_key', 'token', 'password', 'secret', 'authorization'} for key in provider_cfg.keys())
+
+
+provider_service = ProviderService()

--- a/api/tests/test_provider_catalog_api.py
+++ b/api/tests/test_provider_catalog_api.py
@@ -28,7 +28,7 @@ def test_system_providers_and_models_expose_redacted_catalog(tmp_path, monkeypat
             },
             'fallback_providers': ['backup'],
             'models': {
-                'custom': ['gpt-5.4', 'gpt-5-mini'],
+                'custom': ['gpt-5-mini'],
                 'backup': ['glm-5.1'],
             },
         },
@@ -48,6 +48,7 @@ def test_system_providers_and_models_expose_redacted_catalog(tmp_path, monkeypat
     models_payload = models_response.json()
     assert models_payload['default_model'] == 'gpt-5.4'
     assert models_payload['default_provider'] == 'custom'
+    assert {'provider': 'custom', 'id': 'gpt-5.4', 'source': 'config'} in models_payload['models']
     assert models_payload['models'][0]['provider'] == 'backup'
     assert models_payload['models'][0]['id'] == 'glm-5.1'
 
@@ -116,3 +117,32 @@ def test_provider_routing_patch_updates_default_provider_model_and_fallbacks(tmp
     assert stored['model']['default'] == 'glm-5.1'
     assert stored['fallback_providers'] == ['custom']
     assert stored['providers']['custom']['api_key'] == 'super-secret'
+
+
+def test_provider_routing_patch_recovers_from_non_dict_model_shape(tmp_path, monkeypatch) -> None:
+    from app.services import provider_service as provider_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'model': 'broken',
+            'providers': {'custom': {'api_key': 'super-secret'}},
+            'fallback_providers': ['backup'],
+        },
+    )
+
+    monkeypatch.setattr(provider_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path))
+
+    response = client.patch(
+        '/api/system/provider-routing',
+        json={
+            'default_provider': 'custom',
+            'default_model': 'gpt-5.4',
+            'fallback_providers': ['backup'],
+        },
+    )
+
+    assert response.status_code == 200
+    stored = yaml.safe_load(config_path.read_text(encoding='utf-8'))
+    assert stored['model'] == {'provider': 'custom', 'default': 'gpt-5.4'}

--- a/api/tests/test_provider_catalog_api.py
+++ b/api/tests/test_provider_catalog_api.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def write_config(path: Path, payload: dict) -> None:
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
+
+
+def test_system_providers_and_models_expose_redacted_catalog(tmp_path, monkeypatch) -> None:
+    from app.services import provider_service as provider_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'model': {'default': 'gpt-5.4', 'provider': 'custom'},
+            'providers': {
+                'custom': {'api_key': 'super-secret', 'base_url': 'https://providers.example/v1'},
+                'backup': {'api_key': 'backup-secret', 'base_url': 'https://backup.example/v1'},
+            },
+            'fallback_providers': ['backup'],
+            'models': {
+                'custom': ['gpt-5.4', 'gpt-5-mini'],
+                'backup': ['glm-5.1'],
+            },
+        },
+    )
+
+    monkeypatch.setattr(provider_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path))
+
+    providers_response = client.get('/api/system/providers')
+    assert providers_response.status_code == 200
+    providers_payload = providers_response.json()
+    assert providers_payload['total'] == 2
+    assert providers_payload['providers'][0]['name'] == 'backup'
+    assert providers_payload['providers'][0]['config']['api_key'] == '***redacted***'
+
+    models_response = client.get('/api/system/models')
+    assert models_response.status_code == 200
+    models_payload = models_response.json()
+    assert models_payload['default_model'] == 'gpt-5.4'
+    assert models_payload['default_provider'] == 'custom'
+    assert models_payload['models'][0]['provider'] == 'backup'
+    assert models_payload['models'][0]['id'] == 'glm-5.1'
+
+
+def test_provider_routing_endpoint_returns_default_and_fallbacks(tmp_path, monkeypatch) -> None:
+    from app.services import provider_service as provider_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'model': {'default': 'gpt-5.4', 'provider': 'custom'},
+            'providers': {'custom': {'api_key': 'super-secret'}},
+            'fallback_providers': ['backup-a', 'backup-b'],
+        },
+    )
+
+    monkeypatch.setattr(provider_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path))
+
+    response = client.get('/api/system/provider-routing')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        'default_provider': 'custom',
+        'default_model': 'gpt-5.4',
+        'fallback_providers': ['backup-a', 'backup-b'],
+        'effective_provider_count': 3,
+        'write_restrictions': ['Provider credentials remain redacted in provider routing views.'],
+    }
+
+
+def test_provider_routing_patch_updates_default_provider_model_and_fallbacks(tmp_path, monkeypatch) -> None:
+    from app.services import provider_service as provider_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'model': {'default': 'gpt-5.4', 'provider': 'custom'},
+            'providers': {'custom': {'api_key': 'super-secret'}, 'backup': {'api_key': 'backup-secret'}},
+            'fallback_providers': ['backup'],
+        },
+    )
+
+    monkeypatch.setattr(provider_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path))
+
+    response = client.patch(
+        '/api/system/provider-routing',
+        json={
+            'default_provider': 'backup',
+            'default_model': 'glm-5.1',
+            'fallback_providers': ['custom'],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['default_provider'] == 'backup'
+    assert payload['default_model'] == 'glm-5.1'
+    assert payload['fallback_providers'] == ['custom']
+    assert payload['effective_provider_count'] == 2
+
+    stored = yaml.safe_load(config_path.read_text(encoding='utf-8'))
+    assert stored['model']['provider'] == 'backup'
+    assert stored['model']['default'] == 'glm-5.1'
+    assert stored['fallback_providers'] == ['custom']
+    assert stored['providers']['custom']['api_key'] == 'super-secret'

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { CronJobsPage } from './pages/CronJobsPage'
 import { LogsPage } from './pages/LogsPage'
 import { OverviewPage } from './pages/OverviewPage'
 import { ProfilesPage } from './pages/ProfilesPage'
+import { ProvidersPage } from './pages/ProvidersPage'
 import { SessionsPage } from './pages/SessionsPage'
 import { SkillsPage } from './pages/SkillsPage'
 
@@ -20,6 +21,7 @@ function App() {
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/sessions" element={<SessionsPage />} />
         <Route path="/config" element={<ConfigPage />} />
+        <Route path="/providers-models" element={<ProvidersPage />} />
         <Route path="/cron-jobs" element={<CronJobsPage />} />
         <Route path="/logs" element={<LogsPage />} />
       </Route>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2,8 +2,11 @@ import {
   mockAgentConfig,
   mockCronJobs,
   mockLogs,
+  mockModels,
   mockOverview,
   mockProfiles,
+  mockProviderRouting,
+  mockProviders,
   mockRuns,
   mockSessions,
   mockSkills,
@@ -14,8 +17,11 @@ import type {
   CreateProfilePayload,
   CronJob,
   LogEntry,
+  ModelCatalogRecord,
   OverviewResponse,
   Profile,
+  ProviderCatalogRecord,
+  ProviderRoutingRecord,
   RunRecord,
   SessionDetailRecord,
   SessionRecord,
@@ -173,6 +179,35 @@ type BackendAgentConfigResponse = {
   }
   editable_fields: string[]
   deferred_fields: string[]
+  write_restrictions: string[]
+}
+
+type BackendProvidersResponse = {
+  providers: Array<{
+    name: string
+    config: Record<string, unknown>
+    has_credentials: boolean
+    source: string
+  }>
+  total: number
+}
+
+type BackendModelsResponse = {
+  models: Array<{
+    id: string
+    provider: string
+    source: string
+  }>
+  total: number
+  default_model?: string | null
+  default_provider?: string | null
+}
+
+type BackendProviderRoutingResponse = {
+  default_provider?: string | null
+  default_model?: string | null
+  fallback_providers: string[]
+  effective_provider_count: number
   write_restrictions: string[]
 }
 
@@ -346,6 +381,29 @@ const normalizeAgentConfig = (payload: BackendAgentConfigResponse): AgentConfigR
   },
   editableFields: payload.editable_fields,
   deferredFields: payload.deferred_fields,
+  writeRestrictions: payload.write_restrictions,
+})
+
+const normalizeProviders = (payload: BackendProvidersResponse): ProviderCatalogRecord[] =>
+  payload.providers.map((provider) => ({
+    name: provider.name,
+    config: provider.config,
+    hasCredentials: provider.has_credentials,
+    source: provider.source,
+  }))
+
+const normalizeModels = (payload: BackendModelsResponse): ModelCatalogRecord[] =>
+  payload.models.map((model) => ({
+    id: model.id,
+    provider: model.provider,
+    source: model.source,
+  }))
+
+const normalizeProviderRouting = (payload: BackendProviderRoutingResponse): ProviderRoutingRecord => ({
+  defaultProvider: payload.default_provider ?? undefined,
+  defaultModel: payload.default_model ?? undefined,
+  fallbackProviders: payload.fallback_providers,
+  effectiveProviderCount: payload.effective_provider_count,
   writeRestrictions: payload.write_restrictions,
 })
 
@@ -616,4 +674,22 @@ export const apiClient = {
       agentId: profileId,
       path: `/opt/data/hermes/profiles/${profileId}/config.yaml`,
     })),
+
+  getProviders: async (): Promise<ApiResult<ProviderCatalogRecord[]>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendProvidersResponse>('/system/providers')
+      return normalizeProviders(payload)
+    }, () => structuredClone(mockProviders)),
+
+  getModels: async (): Promise<ApiResult<ModelCatalogRecord[]>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendModelsResponse>('/system/models')
+      return normalizeModels(payload)
+    }, () => structuredClone(mockModels)),
+
+  getProviderRouting: async (): Promise<ApiResult<ProviderRoutingRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendProviderRoutingResponse>('/system/provider-routing')
+      return normalizeProviderRouting(payload)
+    }, () => structuredClone(mockProviderRouting)),
 }

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -2,8 +2,11 @@ import type {
   AgentConfigRecord,
   CronJob,
   LogEntry,
+  ModelCatalogRecord,
   OverviewResponse,
   Profile,
+  ProviderCatalogRecord,
+  ProviderRoutingRecord,
   RunRecord,
   SessionRecord,
   Skill,
@@ -242,6 +245,35 @@ export const mockAgentConfig: AgentConfigRecord = {
     'Provider credentials and fallback chains remain read-only in Config v1.',
     'Only personality, model selection, and runtime toggles are writable in this slice.',
   ],
+}
+
+export const mockProviders: ProviderCatalogRecord[] = [
+  {
+    name: 'custom',
+    config: { api_key: '***redacted***', base_url: 'https://providers.gnoviawan.com/v1' },
+    hasCredentials: true,
+    source: 'config',
+  },
+  {
+    name: 'backup',
+    config: { api_key: '***redacted***', base_url: 'https://backup.example/v1' },
+    hasCredentials: true,
+    source: 'config',
+  },
+]
+
+export const mockModels: ModelCatalogRecord[] = [
+  { id: 'gpt-5.4', provider: 'custom', source: 'config' },
+  { id: 'gpt-5-mini', provider: 'custom', source: 'config' },
+  { id: 'glm-5.1', provider: 'backup', source: 'config' },
+]
+
+export const mockProviderRouting: ProviderRoutingRecord = {
+  defaultProvider: 'custom',
+  defaultModel: 'gpt-5.4',
+  fallbackProviders: ['backup'],
+  effectiveProviderCount: 2,
+  writeRestrictions: ['Provider credentials remain redacted in provider routing views.'],
 }
 
 export const mockLogs: LogEntry[] = [

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -5,6 +5,7 @@ import {
   ProfileOutlined,
   RadarChartOutlined,
   SettingOutlined,
+  SwapOutlined,
   ToolOutlined,
 } from '@ant-design/icons'
 import { Layout, Menu, Select, Space, Tag, Typography } from 'antd'
@@ -33,6 +34,7 @@ const navigationItems: MenuProps['items'] = [
     children: [
       { key: '/profiles', icon: <ProfileOutlined />, label: 'Profiles' },
       { key: '/config', icon: <SettingOutlined />, label: 'Config' },
+      { key: '/providers-models', icon: <SwapOutlined />, label: 'Providers & Models' },
       { key: '/skills', icon: <ToolOutlined />, label: 'Skills' },
     ],
   },

--- a/web/src/pages/ProvidersPage.tsx
+++ b/web/src/pages/ProvidersPage.tsx
@@ -1,0 +1,115 @@
+import { Card, Col, List, Row, Space, Table, Tag, Typography } from 'antd'
+import type { ColumnsType } from 'antd/es/table'
+import { apiClient } from '../api/client'
+import { useApiQuery } from '../api/hooks'
+import { PageHeader } from '../components/PageHeader'
+import type { ModelCatalogRecord, ProviderCatalogRecord, ProviderRoutingRecord } from '../types'
+
+const providerColumns: ColumnsType<ProviderCatalogRecord> = [
+  { title: 'Provider', dataIndex: 'name' },
+  { title: 'Source', dataIndex: 'source' },
+  { title: 'Credentials', dataIndex: 'hasCredentials', render: (value: boolean) => <Tag color={value ? 'green' : 'default'}>{value ? 'Configured' : 'Missing'}</Tag> },
+]
+
+const modelColumns: ColumnsType<ModelCatalogRecord> = [
+  { title: 'Model', dataIndex: 'id' },
+  { title: 'Provider', dataIndex: 'provider' },
+  { title: 'Source', dataIndex: 'source' },
+]
+
+export function ProvidersPage() {
+  const providersQuery = useApiQuery<ProviderCatalogRecord[]>(apiClient.getProviders, [])
+  const modelsQuery = useApiQuery<ModelCatalogRecord[]>(apiClient.getModels, [])
+  const routingQuery = useApiQuery<ProviderRoutingRecord>(apiClient.getProviderRouting, [])
+
+  const isMock = providersQuery.isMock || modelsQuery.isMock || routingQuery.isMock
+  const error = providersQuery.error ?? modelsQuery.error ?? routingQuery.error
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="Providers & Models"
+        description="Inspect provider catalogs, model availability, default routing, and fallback chains with secret redaction."
+        mock={isMock}
+        error={error}
+        onRefresh={async () => {
+          await providersQuery.refresh()
+          await modelsQuery.refresh()
+          await routingQuery.refresh()
+        }}
+      />
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Providers</span>
+            <Typography.Title level={3}>{providersQuery.data?.length ?? 0}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Models</span>
+            <Typography.Title level={3}>{modelsQuery.data?.length ?? 0}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Effective providers</span>
+            <Typography.Title level={3}>{routingQuery.data?.effectiveProviderCount ?? 0}</Typography.Title>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={12}>
+          <Card className="glass-panel qwen-section-card" title="Provider catalog" loading={providersQuery.isLoading}>
+            <Table rowKey="name" dataSource={providersQuery.data ?? []} columns={providerColumns} pagination={false} />
+          </Card>
+        </Col>
+        <Col xs={24} xl={12}>
+          <Card className="glass-panel qwen-section-card" title="Model catalog" loading={modelsQuery.isLoading}>
+            <Table rowKey={(record) => `${record.provider}:${record.id}`} dataSource={modelsQuery.data ?? []} columns={modelColumns} pagination={false} />
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={10}>
+          <Card className="glass-panel qwen-section-card" title="Routing summary" loading={routingQuery.isLoading}>
+            <Space direction="vertical" size={10}>
+              <Typography.Text>Default provider: <Typography.Text strong>{routingQuery.data?.defaultProvider ?? '—'}</Typography.Text></Typography.Text>
+              <Typography.Text>Default model: <Typography.Text strong>{routingQuery.data?.defaultModel ?? '—'}</Typography.Text></Typography.Text>
+              <Typography.Text>Fallbacks:</Typography.Text>
+              <Space wrap>
+                {(routingQuery.data?.fallbackProviders ?? []).map((provider) => <Tag key={provider} color="gold">{provider}</Tag>)}
+              </Space>
+            </Space>
+          </Card>
+        </Col>
+        <Col xs={24} xl={14}>
+          <Card className="glass-panel qwen-section-card" title="Provider configs (redacted)" loading={providersQuery.isLoading}>
+            <List
+              dataSource={providersQuery.data ?? []}
+              renderItem={(item) => (
+                <List.Item>
+                  <List.Item.Meta
+                    title={item.name}
+                    description={<pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{JSON.stringify(item.config, null, 2)}</pre>}
+                  />
+                </List.Item>
+              )}
+            />
+          </Card>
+        </Col>
+      </Row>
+
+      <Card className="glass-panel qwen-section-card" title="Write restrictions" loading={routingQuery.isLoading}>
+        <List
+          size="small"
+          dataSource={routingQuery.data?.writeRestrictions ?? []}
+          renderItem={(item) => <List.Item>{item}</List.Item>}
+        />
+      </Card>
+    </div>
+  )
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -132,6 +132,27 @@ export interface AgentConfigRecord {
   writeRestrictions: string[]
 }
 
+export interface ProviderCatalogRecord {
+  name: string
+  config: Record<string, unknown>
+  hasCredentials: boolean
+  source: string
+}
+
+export interface ModelCatalogRecord {
+  id: string
+  provider: string
+  source: string
+}
+
+export interface ProviderRoutingRecord {
+  defaultProvider?: string
+  defaultModel?: string
+  fallbackProviders: string[]
+  effectiveProviderCount: number
+  writeRestrictions: string[]
+}
+
 export interface LogEntry {
   id: string
   timestamp: string


### PR DESCRIPTION
## Summary
- add stable system-scoped provider, model, and routing contracts plus a dedicated provider service
- redact provider credentials while exposing provider catalog, model catalog, and fallback routing state
- wire a Providers & Models page to the new system endpoints with catalog and routing views

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_provider_catalog_api.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build

Closes #7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Providers & Models" management page accessible from Settings navigation
  * View available providers and their associated models with catalog information
  * Manage provider routing configuration including setting default providers/models and configuring fallback provider lists
  * Provider credentials are securely redacted across all views for data protection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->