### PR TITLE
feat: add tools and toolsets contracts

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -39,6 +39,10 @@ from app.models import (
     StatusResponse,
     SystemHealthResponse,
     SystemVersionResponse,
+    ToolCatalogResponse,
+    ToolInfo,
+    ToolsetPatchRequest,
+    ToolsetResponse,
 )
 from app.services.hermes_adapter import (
     active_profile_name,
@@ -59,6 +63,7 @@ from app.services.provider_service import provider_service
 from app.services.run_service import run_service
 from app.services.runtime_registry import runtime_registry
 from app.services.session_service import session_service
+from app.services.tool_service import tool_service
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
 
@@ -138,6 +143,16 @@ def get_system_provider_routing() -> ProviderRoutingResponse:
 @app.patch('/api/system/provider-routing', response_model=ProviderRoutingResponse, tags=['system'])
 def patch_system_provider_routing(payload: ProviderRoutingPatchRequest) -> ProviderRoutingResponse:
     return provider_service.patch_routing(payload.model_dump(exclude_none=True))
+
+
+@app.get('/api/system/toolsets', response_model=ToolsetResponse, tags=['system'])
+def get_system_toolsets() -> ToolsetResponse:
+    return tool_service.list_system_toolsets()
+
+
+@app.get('/api/system/tools', response_model=ToolCatalogResponse, tags=['system'])
+def get_system_tools() -> ToolCatalogResponse:
+    return tool_service.list_system_tools()
 
 
 @app.get('/api/status', response_model=StatusResponse, tags=['system'])
@@ -229,6 +244,24 @@ def post_profiles(payload: CreateProfileRequest) -> dict:
 @app.get('/api/sessions', tags=['sessions'])
 def get_sessions(profile: str = Query('default')) -> dict:
     return {'profile': profile, 'sessions': [item.model_dump() for item in list_sessions(profile)]}
+
+
+@app.get('/api/agents/{agent_id}/toolsets', response_model=ToolsetResponse, tags=['tools'])
+def list_agent_toolsets(agent_id: str) -> ToolsetResponse:
+    ensure_profile_exists(agent_id)
+    return tool_service.list_agent_toolsets(agent_id)
+
+
+@app.patch('/api/agents/{agent_id}/toolsets', response_model=ToolsetResponse, tags=['tools'])
+def patch_agent_toolsets(agent_id: str, payload: ToolsetPatchRequest) -> ToolsetResponse:
+    ensure_profile_exists(agent_id)
+    return tool_service.patch_agent_toolsets(agent_id, payload)
+
+
+@app.get('/api/agents/{agent_id}/tools', response_model=ToolCatalogResponse, tags=['tools'])
+def list_agent_tools(agent_id: str) -> ToolCatalogResponse:
+    ensure_profile_exists(agent_id)
+    return tool_service.list_agent_tools(agent_id)
 
 
 @app.get('/api/agents/{agent_id}/sessions/search', response_model=SessionSearchResponse, tags=['sessions'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -309,6 +309,39 @@ class ProviderRoutingPatchRequest(BaseModel):
     fallback_providers: list[str] | None = None
 
 
+class ToolsetInfo(BaseModel):
+    name: str
+    source: str
+    enabled: bool = True
+    tool_count: int = 0
+
+
+class ToolsetResponse(BaseModel):
+    agent_id: str
+    toolsets: list[ToolsetInfo]
+    total: int
+
+
+class ToolsetPatchRequest(BaseModel):
+    toolsets: list[str]
+
+
+class ToolInfo(BaseModel):
+    name: str
+    toolset: str
+    source_type: str
+    source_id: str | None = None
+    available: bool = True
+    availability_reason: str | None = None
+    schema_summary: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolCatalogResponse(BaseModel):
+    agent_id: str
+    tools: list[ToolInfo]
+    total: int
+
+
 class StatusResponse(BaseModel):
     ok: bool
     active_profile: str

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import config_service, provider_service, session_service
+from . import config_service, provider_service, session_service, tool_service
 
-__all__ = ["config_service", "provider_service", "session_service"]
+__all__ = ["config_service", "provider_service", "session_service", "tool_service"]

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from threading import RLock
+from typing import Any
+
+import yaml
+
+from app.models import ToolCatalogResponse, ToolInfo, ToolsetInfo, ToolsetPatchRequest, ToolsetResponse
+from app.services.hermes_adapter import ensure_profile_exists, profile_contexts
+from app.utils import load_yaml_file
+
+_BUILTIN_TOOLSETS: dict[str, list[str]] = {
+    'browser': ['browser_navigate', 'browser_snapshot'],
+    'file': ['read_file', 'write_file', 'patch'],
+    'hermes-cli': ['terminal', 'read_file', 'write_file', 'patch', 'browser_navigate'],
+}
+
+_WRITE_LOCK = RLock()
+
+
+class ToolService:
+    def list_agent_toolsets(self, agent_id: str) -> ToolsetResponse:
+        context = ensure_profile_exists(agent_id)
+        toolsets = self._resolve_toolsets(context.home)
+        return ToolsetResponse(agent_id=agent_id, toolsets=toolsets, total=len(toolsets))
+
+    def patch_agent_toolsets(self, agent_id: str, payload: ToolsetPatchRequest) -> ToolsetResponse:
+        context = ensure_profile_exists(agent_id)
+        config_path = context.home / 'config.yaml'
+        with _WRITE_LOCK:
+            config = load_yaml_file(config_path)
+            config['toolsets'] = payload.toolsets
+            self._atomic_write_yaml(config_path, config)
+        return self.list_agent_toolsets(agent_id)
+
+    def list_agent_tools(self, agent_id: str) -> ToolCatalogResponse:
+        context = ensure_profile_exists(agent_id)
+        tools = self._resolve_tools(context.home)
+        return ToolCatalogResponse(agent_id=agent_id, tools=tools, total=len(tools))
+
+    def list_system_toolsets(self) -> ToolsetResponse:
+        seen: dict[str, ToolsetInfo] = {}
+        for context in profile_contexts():
+            for toolset in self._resolve_toolsets(context.home):
+                seen.setdefault(toolset.name, toolset)
+        toolsets = [seen[name] for name in sorted(seen)]
+        return ToolsetResponse(agent_id='system', toolsets=toolsets, total=len(toolsets))
+
+    def list_system_tools(self) -> ToolCatalogResponse:
+        seen: dict[str, ToolInfo] = {}
+        for context in profile_contexts():
+            for tool in self._resolve_tools(context.home):
+                seen.setdefault(tool.name, tool)
+        tools = [seen[name] for name in sorted(seen)]
+        return ToolCatalogResponse(agent_id='system', tools=tools, total=len(tools))
+
+    def _resolve_toolsets(self, home: Path) -> list[ToolsetInfo]:
+        config = load_yaml_file(home / 'config.yaml')
+        configured = config.get('toolsets') if isinstance(config.get('toolsets'), list) else []
+        mcp_servers = config.get('mcp_servers') if isinstance(config.get('mcp_servers'), dict) else {}
+        items = [
+            ToolsetInfo(name=name, source='builtin', enabled=True, tool_count=len(self._builtin_tools(name)))
+            for name in sorted({str(name) for name in configured})
+        ]
+        items.extend(
+            ToolsetInfo(name=f'mcp:{server_name}', source='mcp', enabled=True, tool_count=1)
+            for server_name in sorted(mcp_servers)
+        )
+        return items
+
+    def _resolve_tools(self, home: Path) -> list[ToolInfo]:
+        config = load_yaml_file(home / 'config.yaml')
+        configured = config.get('toolsets') if isinstance(config.get('toolsets'), list) else []
+        mcp_servers = config.get('mcp_servers') if isinstance(config.get('mcp_servers'), dict) else {}
+        tools: dict[str, ToolInfo] = {}
+        for toolset in configured:
+            for tool_name in self._builtin_tools(str(toolset)):
+                tools.setdefault(
+                    tool_name,
+                    ToolInfo(
+                        name=tool_name,
+                        toolset=str(toolset),
+                        source_type='builtin',
+                        source_id=str(toolset),
+                        available=True,
+                        availability_reason='Enabled by configured toolset',
+                        schema_summary={'type': 'builtin'},
+                    ),
+                )
+        for server_name in sorted(mcp_servers):
+            tool_name = f'mcp__{server_name}'
+            tools[tool_name] = ToolInfo(
+                name=tool_name,
+                toolset=f'mcp:{server_name}',
+                source_type='mcp',
+                source_id=server_name,
+                available=True,
+                availability_reason='MCP server configured',
+                schema_summary={'type': 'mcp'},
+            )
+        return [tools[name] for name in sorted(tools)]
+
+    def _builtin_tools(self, toolset: str) -> list[str]:
+        return _BUILTIN_TOOLSETS.get(toolset, [])
+
+    def _atomic_write_yaml(self, path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile('w', encoding='utf-8', dir=path.parent, delete=False) as handle:
+            yaml.safe_dump(payload, handle, sort_keys=False)
+            temp_path = Path(handle.name)
+        temp_path.replace(path)
+
+
+tool_service = ToolService()

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from threading import RLock
 from typing import Any
 
 import yaml
+from fastapi import HTTPException
 
 from app.models import ToolCatalogResponse, ToolInfo, ToolsetInfo, ToolsetPatchRequest, ToolsetResponse
 from app.services.hermes_adapter import ensure_profile_exists, profile_contexts
@@ -30,7 +32,7 @@ class ToolService:
         context = ensure_profile_exists(agent_id)
         config_path = context.home / 'config.yaml'
         with _WRITE_LOCK:
-            config = load_yaml_file(config_path)
+            config = self._load_writable_config(config_path)
             config['toolsets'] = payload.toolsets
             self._atomic_write_yaml(config_path, config)
         return self.list_agent_toolsets(agent_id)
@@ -105,12 +107,32 @@ class ToolService:
     def _builtin_tools(self, toolset: str) -> list[str]:
         return _BUILTIN_TOOLSETS.get(toolset, [])
 
+    def _load_writable_config(self, path: Path) -> dict[str, Any]:
+        if not path.exists():
+            return {}
+        try:
+            raw = yaml.safe_load(path.read_text(encoding='utf-8'))
+        except (OSError, yaml.YAMLError) as exc:
+            raise HTTPException(status_code=409, detail='Cannot update toolsets because config.yaml is unreadable or malformed.') from exc
+        if raw is None:
+            return {}
+        if not isinstance(raw, dict):
+            raise HTTPException(status_code=409, detail='Cannot update toolsets because config.yaml is unreadable or malformed.')
+        return raw
+
     def _atomic_write_yaml(self, path: Path, payload: dict[str, Any]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with NamedTemporaryFile('w', encoding='utf-8', dir=path.parent, delete=False) as handle:
-            yaml.safe_dump(payload, handle, sort_keys=False)
-            temp_path = Path(handle.name)
-        temp_path.replace(path)
+        temp_path: Path | None = None
+        try:
+            with NamedTemporaryFile('w', encoding='utf-8', dir=path.parent, delete=False) as handle:
+                yaml.safe_dump(payload, handle, sort_keys=False)
+                handle.flush()
+                os.fsync(handle.fileno())
+                temp_path = Path(handle.name)
+            temp_path.replace(path)
+        finally:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink(missing_ok=True)
 
 
 tool_service = ToolService()

--- a/api/tests/test_tools_api.py
+++ b/api/tests/test_tools_api.py
@@ -98,3 +98,20 @@ def test_agent_toolsets_patch_replaces_enabled_toolsets(tmp_path, monkeypatch) -
     assert [item['name'] for item in payload['toolsets']] == ['browser']
     stored = yaml.safe_load(config_path.read_text(encoding='utf-8'))
     assert stored['toolsets'] == ['browser']
+
+
+def test_agent_toolsets_patch_rejects_malformed_yaml_without_overwriting_file(tmp_path, monkeypatch) -> None:
+    from app.services import tool_service as tool_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    malformed = 'toolsets: [hermes-cli\n'
+    config_path.write_text(malformed, encoding='utf-8')
+
+    monkeypatch.setattr(tool_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.patch('/api/agents/default/toolsets', json={'toolsets': ['browser']})
+
+    assert response.status_code == 409
+    assert response.json()['detail'] == 'Cannot update toolsets because config.yaml is unreadable or malformed.'
+    assert config_path.read_text(encoding='utf-8') == malformed

--- a/api/tests/test_tools_api.py
+++ b/api/tests/test_tools_api.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+
+import yaml
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def write_config(path, payload: dict) -> None:
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
+
+
+def test_agent_toolsets_and_tools_expand_builtin_and_mcp_inventory(tmp_path, monkeypatch) -> None:
+    from app.services import tool_service as tool_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'toolsets': ['hermes-cli', 'browser'],
+            'mcp_servers': {
+                'mempalace': {'command': '/usr/bin/python3'},
+            },
+        },
+    )
+
+    monkeypatch.setattr(tool_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    toolsets_response = client.get('/api/agents/default/toolsets')
+    assert toolsets_response.status_code == 200
+    toolsets_payload = toolsets_response.json()
+    assert toolsets_payload['agent_id'] == 'default'
+    assert toolsets_payload['total'] == 3
+    assert [item['name'] for item in toolsets_payload['toolsets']] == ['browser', 'hermes-cli', 'mcp:mempalace']
+    assert toolsets_payload['toolsets'][0]['source'] == 'builtin'
+    assert toolsets_payload['toolsets'][2]['source'] == 'mcp'
+
+    tools_response = client.get('/api/agents/default/tools')
+    assert tools_response.status_code == 200
+    tools_payload = tools_response.json()
+    names = [item['name'] for item in tools_payload['tools']]
+    assert 'browser_navigate' in names
+    assert 'terminal' in names
+    assert 'mcp__mempalace' in names
+    mcp_tool = next(item for item in tools_payload['tools'] if item['name'] == 'mcp__mempalace')
+    assert mcp_tool['source_type'] == 'mcp'
+    assert mcp_tool['source_id'] == 'mempalace'
+    assert mcp_tool['availability_reason'] == 'MCP server configured'
+
+
+def test_system_tool_catalog_deduplicates_inventory_across_profiles(tmp_path, monkeypatch) -> None:
+    from app.services import tool_service as tool_service_module
+
+    default_home = tmp_path / 'default-home'
+    default_home.mkdir()
+    write_config(default_home / 'config.yaml', {'toolsets': ['hermes-cli']})
+
+    ops_home = tmp_path / 'ops-home'
+    ops_home.mkdir()
+    write_config(ops_home / 'config.yaml', {'toolsets': ['browser', 'hermes-cli']})
+
+    def fake_profile_contexts():
+        return [SimpleNamespace(profile='default', home=default_home), SimpleNamespace(profile='ops', home=ops_home)]
+
+    monkeypatch.setattr(tool_service_module, 'profile_contexts', fake_profile_contexts)
+
+    response = client.get('/api/system/toolsets')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['total'] == 2
+    assert [item['name'] for item in payload['toolsets']] == ['browser', 'hermes-cli']
+
+    tools_response = client.get('/api/system/tools')
+    assert tools_response.status_code == 200
+    tools_payload = tools_response.json()
+    assert any(item['name'] == 'browser_navigate' for item in tools_payload['tools'])
+    assert any(item['name'] == 'terminal' for item in tools_payload['tools'])
+
+
+def test_agent_toolsets_patch_replaces_enabled_toolsets(tmp_path, monkeypatch) -> None:
+    from app.services import tool_service as tool_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(config_path, {'toolsets': ['hermes-cli']})
+
+    monkeypatch.setattr(tool_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.patch('/api/agents/default/toolsets', json={'toolsets': ['browser']})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item['name'] for item in payload['toolsets']] == ['browser']
+    stored = yaml.safe_load(config_path.read_text(encoding='utf-8'))
+    assert stored['toolsets'] == ['browser']

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { ProfilesPage } from './pages/ProfilesPage'
 import { ProvidersPage } from './pages/ProvidersPage'
 import { SessionsPage } from './pages/SessionsPage'
 import { SkillsPage } from './pages/SkillsPage'
+import { ToolsPage } from './pages/ToolsPage'
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
         <Route path="/console" element={<ConsolePage />} />
         <Route path="/profiles" element={<ProfilesPage />} />
         <Route path="/skills" element={<SkillsPage />} />
+        <Route path="/tools" element={<ToolsPage />} />
         <Route path="/sessions" element={<SessionsPage />} />
         <Route path="/config" element={<ConfigPage />} />
         <Route path="/providers-models" element={<ProvidersPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10,6 +10,8 @@ import {
   mockRuns,
   mockSessions,
   mockSkills,
+  mockTools,
+  mockToolsets,
 } from './mockData'
 import type {
   AgentConfigRecord,
@@ -28,6 +30,8 @@ import type {
   Skill,
   SkillBroadcastPayload,
   ToggleSkillPayload,
+  ToolRecord,
+  ToolsetRecord,
 } from '../types'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api'
@@ -209,6 +213,31 @@ type BackendProviderRoutingResponse = {
   fallback_providers: string[]
   effective_provider_count: number
   write_restrictions: string[]
+}
+
+type BackendToolsetsResponse = {
+  agent_id: string
+  toolsets: Array<{
+    name: string
+    source: 'builtin' | 'mcp'
+    enabled: boolean
+    tool_count: number
+  }>
+  total: number
+}
+
+type BackendToolsResponse = {
+  agent_id: string
+  tools: Array<{
+    name: string
+    toolset: string
+    source_type: 'builtin' | 'mcp'
+    source_id?: string | null
+    available: boolean
+    availability_reason?: string | null
+    schema_summary: Record<string, unknown>
+  }>
+  total: number
 }
 
 type BackendCreateProfileResponse = {
@@ -406,6 +435,25 @@ const normalizeProviderRouting = (payload: BackendProviderRoutingResponse): Prov
   effectiveProviderCount: payload.effective_provider_count,
   writeRestrictions: payload.write_restrictions,
 })
+
+const normalizeToolsets = (payload: BackendToolsetsResponse): ToolsetRecord[] =>
+  payload.toolsets.map((toolset) => ({
+    name: toolset.name,
+    source: toolset.source,
+    enabled: toolset.enabled,
+    toolCount: toolset.tool_count,
+  }))
+
+const normalizeTools = (payload: BackendToolsResponse): ToolRecord[] =>
+  payload.tools.map((tool) => ({
+    name: tool.name,
+    toolset: tool.toolset,
+    sourceType: tool.source_type,
+    sourceId: tool.source_id ?? undefined,
+    available: tool.available,
+    availabilityReason: tool.availability_reason ?? undefined,
+    schemaSummary: tool.schema_summary,
+  }))
 
 async function withFallback<T>(run: () => Promise<T>, fallback: () => T): Promise<ApiResult<T>> {
   try {
@@ -692,4 +740,16 @@ export const apiClient = {
       const payload = await fetchJson<BackendProviderRoutingResponse>('/system/provider-routing')
       return normalizeProviderRouting(payload)
     }, () => structuredClone(mockProviderRouting)),
+
+  getAgentToolsets: async (profileId: string): Promise<ApiResult<ToolsetRecord[]>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendToolsetsResponse>(`/agents/${encodeURIComponent(profileId)}/toolsets`)
+      return normalizeToolsets(payload)
+    }, () => structuredClone(mockToolsets)),
+
+  getAgentTools: async (profileId: string): Promise<ApiResult<ToolRecord[]>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendToolsResponse>(`/agents/${encodeURIComponent(profileId)}/tools`)
+      return normalizeTools(payload)
+    }, () => structuredClone(mockTools)),
 }

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -10,6 +10,8 @@ import type {
   RunRecord,
   SessionRecord,
   Skill,
+  ToolRecord,
+  ToolsetRecord,
 } from '../types'
 
 export const mockProfiles: Profile[] = [
@@ -275,6 +277,42 @@ export const mockProviderRouting: ProviderRoutingRecord = {
   effectiveProviderCount: 2,
   writeRestrictions: ['Provider credentials remain redacted in provider routing views.'],
 }
+
+export const mockToolsets: ToolsetRecord[] = [
+  { name: 'browser', source: 'builtin', enabled: true, toolCount: 2 },
+  { name: 'hermes-cli', source: 'builtin', enabled: true, toolCount: 5 },
+  { name: 'mcp:mempalace', source: 'mcp', enabled: true, toolCount: 1 },
+]
+
+export const mockTools: ToolRecord[] = [
+  {
+    name: 'browser_navigate',
+    toolset: 'browser',
+    sourceType: 'builtin',
+    sourceId: 'browser',
+    available: true,
+    availabilityReason: 'Enabled by configured toolset',
+    schemaSummary: { type: 'builtin' },
+  },
+  {
+    name: 'terminal',
+    toolset: 'hermes-cli',
+    sourceType: 'builtin',
+    sourceId: 'hermes-cli',
+    available: true,
+    availabilityReason: 'Enabled by configured toolset',
+    schemaSummary: { type: 'builtin' },
+  },
+  {
+    name: 'mcp__mempalace',
+    toolset: 'mcp:mempalace',
+    sourceType: 'mcp',
+    sourceId: 'mempalace',
+    available: true,
+    availabilityReason: 'MCP server configured',
+    schemaSummary: { type: 'mcp' },
+  },
+]
 
 export const mockLogs: LogEntry[] = [
   {

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -24,6 +24,7 @@ const navigationItems: MenuProps['items'] = [
       { key: '/overview', label: 'Overview' },
       { key: '/console', icon: <ConsoleSqlOutlined />, label: 'Console' },
       { key: '/sessions', icon: <RadarChartOutlined />, label: 'Sessions' },
+      { key: '/tools', icon: <ToolOutlined />, label: 'Tools' },
       { key: '/cron-jobs', icon: <ClockCircleOutlined />, label: 'Cron Jobs' },
       { key: '/logs', icon: <FileTextOutlined />, label: 'Logs' },
     ],

--- a/web/src/pages/ToolsPage.tsx
+++ b/web/src/pages/ToolsPage.tsx
@@ -1,0 +1,101 @@
+import { Card, Col, List, Row, Space, Table, Tag, Typography } from 'antd'
+import type { ColumnsType } from 'antd/es/table'
+import { apiClient } from '../api/client'
+import { useApiQuery } from '../api/hooks'
+import { PageHeader } from '../components/PageHeader'
+import { useProfileStore } from '../store/profileStore'
+import type { ToolRecord, ToolsetRecord } from '../types'
+
+const toolsetColumns: ColumnsType<ToolsetRecord> = [
+  { title: 'Toolset', dataIndex: 'name' },
+  { title: 'Source', dataIndex: 'source', render: (value: ToolsetRecord['source']) => <Tag color={value === 'mcp' ? 'purple' : 'blue'}>{value}</Tag> },
+  { title: 'Status', dataIndex: 'enabled', render: (value: boolean) => <Tag color={value ? 'green' : 'default'}>{value ? 'Enabled' : 'Disabled'}</Tag> },
+  { title: 'Tools', dataIndex: 'toolCount' },
+]
+
+const toolColumns: ColumnsType<ToolRecord> = [
+  { title: 'Tool', dataIndex: 'name' },
+  { title: 'Toolset', dataIndex: 'toolset' },
+  { title: 'Source', dataIndex: 'sourceType', render: (value: ToolRecord['sourceType']) => <Tag color={value === 'mcp' ? 'purple' : 'blue'}>{value}</Tag> },
+  { title: 'Availability', dataIndex: 'available', render: (value: boolean) => <Tag color={value ? 'green' : 'red'}>{value ? 'Available' : 'Unavailable'}</Tag> },
+]
+
+export function ToolsPage() {
+  const { selectedProfileId } = useProfileStore()
+  const profileId = selectedProfileId ?? 'default'
+  const toolsetsQuery = useApiQuery<ToolsetRecord[]>(() => apiClient.getAgentToolsets(profileId), [profileId])
+  const toolsQuery = useApiQuery<ToolRecord[]>(() => apiClient.getAgentTools(profileId), [profileId])
+
+  const isMock = toolsetsQuery.isMock || toolsQuery.isMock
+  const error = toolsetsQuery.error ?? toolsQuery.error
+  const mcpTools = (toolsQuery.data ?? []).filter((tool) => tool.sourceType === 'mcp')
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="Tools & Toolsets"
+        description="Inspect profile-scoped toolsets, expanded tools, and MCP-injected capabilities."
+        mock={isMock}
+        error={error}
+        onRefresh={async () => {
+          await toolsetsQuery.refresh()
+          await toolsQuery.refresh()
+        }}
+      />
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Current profile</span>
+            <Typography.Title level={3}>{profileId}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Enabled toolsets</span>
+            <Typography.Title level={3}>{toolsetsQuery.data?.length ?? 0}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Resolved tools</span>
+            <Typography.Title level={3}>{toolsQuery.data?.length ?? 0}</Typography.Title>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={10}>
+          <Card className="glass-panel qwen-section-card" title="Toolsets" loading={toolsetsQuery.isLoading}>
+            <Table rowKey="name" columns={toolsetColumns} dataSource={toolsetsQuery.data ?? []} pagination={false} />
+          </Card>
+        </Col>
+        <Col xs={24} xl={14}>
+          <Card className="glass-panel qwen-section-card" title="Resolved tools" loading={toolsQuery.isLoading}>
+            <Table rowKey="name" columns={toolColumns} dataSource={toolsQuery.data ?? []} pagination={false} expandable={{ expandedRowRender: (record) => <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{JSON.stringify(record.schemaSummary, null, 2)}</pre> }} />
+          </Card>
+        </Col>
+      </Row>
+
+      <Card className="glass-panel qwen-section-card" title="MCP surfaced tools" loading={toolsQuery.isLoading}>
+        <List
+          dataSource={mcpTools}
+          locale={{ emptyText: 'No MCP tools resolved for this profile.' }}
+          renderItem={(tool) => (
+            <List.Item>
+              <List.Item.Meta
+                title={tool.name}
+                description={
+                  <Space direction="vertical" size={4}>
+                    <Typography.Text>{tool.availabilityReason ?? 'No availability note.'}</Typography.Text>
+                    <Typography.Text type="secondary">Source: {tool.sourceId ?? tool.toolset}</Typography.Text>
+                  </Space>
+                }
+              />
+            </List.Item>
+          )}
+        />
+      </Card>
+    </div>
+  )
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -153,6 +153,23 @@ export interface ProviderRoutingRecord {
   writeRestrictions: string[]
 }
 
+export interface ToolsetRecord {
+  name: string
+  source: 'builtin' | 'mcp'
+  enabled: boolean
+  toolCount: number
+}
+
+export interface ToolRecord {
+  name: string
+  toolset: string
+  sourceType: 'builtin' | 'mcp'
+  sourceId?: string
+  available: boolean
+  availabilityReason?: string
+  schemaSummary: Record<string, unknown>
+}
+
 export interface LogEntry {
   id: string
   timestamp: string


### PR DESCRIPTION
## Summary
- add stable toolset and tool inventory contracts plus a dedicated tool service
- expose agent-scoped toolsets/tools and system-scoped catalog endpoints with MCP-aware expansion
- wire a Tools page to the new agent-scoped endpoints with toolset, inventory, and MCP surfaced views

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_tools_api.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build

Closes #8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tools management page to view and manage agent toolsets and available tools
  * New REST API endpoints for retrieving system-wide and agent-scoped toolsets and tools
  * Tools dashboard displays enabled toolsets, tool catalogs with source information, availability status, and tool schema details

* **Tests**
  * Added comprehensive test coverage for tools/toolsets API endpoints and functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->