### PR TITLE
feat: add skills library contracts

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -25,6 +25,10 @@ from app.models import (
     AgentSecurityPatchRequest,
     AgentSecurityResponse,
     AgentsResponse,
+    AgentSkill,
+    AgentSkillPatchRequest,
+    AgentSkillRunResponse,
+    AgentSkillsResponse,
     AgentSessionsResponse,
     AgentSummary,
     ApprovalQueueResponse,
@@ -48,6 +52,7 @@ from app.models import (
     SystemAllowlistsResponse,
     SystemHealthResponse,
     SystemSecurityResponse,
+    SystemSkillsLibraryResponse,
     SystemVersionResponse,
     ToolCatalogResponse,
     ToolInfo,
@@ -75,6 +80,7 @@ from app.services.run_service import run_service
 from app.services.runtime_registry import runtime_registry
 from app.services.security_service import security_service
 from app.services.session_service import session_service
+from app.services.skill_service import skill_service
 from app.services.tool_service import tool_service
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
@@ -326,6 +332,40 @@ def get_agent_session(agent_id: str, session_id: str) -> SessionDetail:
 def get_skills(profile: str = Query('default')) -> SkillsResponse:
     skills = list_skills(profile)
     return SkillsResponse(profile=profile, total=len(skills), skills=skills)
+
+
+@app.get('/api/agents/{agent_id}/skills', response_model=AgentSkillsResponse, tags=['skills'])
+def list_agent_skills(agent_id: str) -> AgentSkillsResponse:
+    ensure_profile_exists(agent_id)
+    return skill_service.list_agent_skills(agent_id)
+
+
+@app.get('/api/agents/{agent_id}/skills/{skill_name}', response_model=AgentSkill, tags=['skills'])
+def get_agent_skill(agent_id: str, skill_name: str) -> AgentSkill:
+    ensure_profile_exists(agent_id)
+    return skill_service.get_agent_skill(agent_id, skill_name)
+
+
+@app.patch('/api/agents/{agent_id}/skills/{skill_name}', response_model=AgentSkill, tags=['skills'])
+def patch_agent_skill(agent_id: str, skill_name: str, payload: AgentSkillPatchRequest) -> AgentSkill:
+    ensure_profile_exists(agent_id)
+    return skill_service.patch_agent_skill(agent_id, skill_name, payload)
+
+
+@app.post('/api/agents/{agent_id}/skills/{skill_name}/run', response_model=AgentSkillRunResponse, tags=['skills'])
+def run_agent_skill(agent_id: str, skill_name: str) -> AgentSkillRunResponse:
+    ensure_profile_exists(agent_id)
+    return skill_service.run_agent_skill(agent_id, skill_name)
+
+
+@app.get('/api/system/skills', response_model=SystemSkillsLibraryResponse, tags=['skills'])
+def get_system_skills() -> SystemSkillsLibraryResponse:
+    return skill_service.list_system_library()
+
+
+@app.get('/api/system/skills/catalog', response_model=SystemSkillsLibraryResponse, tags=['skills'])
+def get_system_skills_catalog() -> SystemSkillsLibraryResponse:
+    return skill_service.list_system_library()
 
 
 @app.post('/api/skills/broadcast', response_model=SkillBroadcastResult, tags=['skills'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -200,6 +200,49 @@ class SkillsResponse(BaseModel):
     skills: list[SkillSummary]
 
 
+class AgentSkill(BaseModel):
+    name: str
+    category: str | None = None
+    description: str | None = None
+    source: str | None = None
+    installed: bool = True
+    enabled: bool = True
+    updated_at: str | None = None
+
+
+class AgentSkillsResponse(BaseModel):
+    agent_id: str
+    skills: list[AgentSkill]
+    total: int
+
+
+class AgentSkillPatchRequest(BaseModel):
+    enabled: bool | None = None
+
+
+class AgentSkillRunResponse(BaseModel):
+    agent_id: str
+    skill_name: str
+    status: str
+    requested_at: str
+    message: str
+
+
+class SystemSkillLibraryItem(BaseModel):
+    name: str
+    category: str | None = None
+    description: str | None = None
+    source: str | None = None
+    installed_profiles: list[str] = Field(default_factory=list)
+    profile_count: int
+    updated_at: str | None = None
+
+
+class SystemSkillsLibraryResponse(BaseModel):
+    skills: list[SystemSkillLibraryItem]
+    total: int
+
+
 class SkillBroadcastRequest(BaseModel):
     source_profile: str = Field(..., description="Profile to copy from")
     target_profiles: list[str] = Field(..., min_length=1)

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import config_service, cron_service, provider_service, security_service, session_service, tool_service
+from . import config_service, cron_service, provider_service, security_service, session_service, skill_service, tool_service
 
-__all__ = ["config_service", "cron_service", "provider_service", "security_service", "session_service", "tool_service"]
+__all__ = ["config_service", "cron_service", "provider_service", "security_service", "session_service", "skill_service", "tool_service"]

--- a/api/app/services/skill_service.py
+++ b/api/app/services/skill_service.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from threading import RLock
+from typing import Any
+
+from fastapi import HTTPException
+
+from app.models import AgentSkill, AgentSkillPatchRequest, AgentSkillRunResponse, AgentSkillsResponse, SystemSkillLibraryItem, SystemSkillsLibraryResponse
+from app.services.hermes_adapter import ensure_profile_exists, profile_contexts
+from app.utils import load_json_file
+
+_WRITE_LOCK = RLock()
+
+
+class SkillService:
+    def list_agent_skills(self, agent_id: str) -> AgentSkillsResponse:
+        skills = [self._scan_skill(agent_id, skill_file) for skill_file in self._skill_files(agent_id)]
+        return AgentSkillsResponse(agent_id=agent_id, skills=skills, total=len(skills))
+
+    def get_agent_skill(self, agent_id: str, skill_name: str) -> AgentSkill:
+        skill = self._find_skill(agent_id, skill_name)
+        if skill is None:
+            raise HTTPException(status_code=404, detail=f'Skill {skill_name} not found')
+        return skill
+
+    def patch_agent_skill(self, agent_id: str, skill_name: str, payload: AgentSkillPatchRequest) -> AgentSkill:
+        skill = self._find_skill(agent_id, skill_name)
+        if skill is None:
+            raise HTTPException(status_code=404, detail=f'Skill {skill_name} not found')
+        if payload.enabled is not None:
+            with _WRITE_LOCK:
+                registry = self._load_registry(agent_id)
+                registry[skill_name] = {'enabled': payload.enabled}
+                self._write_registry(agent_id, registry)
+        return self.get_agent_skill(agent_id, skill_name)
+
+    def run_agent_skill(self, agent_id: str, skill_name: str) -> AgentSkillRunResponse:
+        skill = self._find_skill(agent_id, skill_name)
+        if skill is None:
+            raise HTTPException(status_code=404, detail=f'Skill {skill_name} not found')
+        now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+        return AgentSkillRunResponse(
+            agent_id=agent_id,
+            skill_name=skill_name,
+            status='queued',
+            requested_at=now,
+            message=f'Skill {skill_name} queued for execution on {agent_id}.',
+        )
+
+    def list_system_library(self) -> SystemSkillsLibraryResponse:
+        aggregated: dict[str, dict[str, Any]] = {}
+        for context in profile_contexts():
+            for skill_file in self._skill_files(context.profile):
+                skill = self._scan_skill(context.profile, skill_file)
+                existing = aggregated.setdefault(
+                    skill.name,
+                    {
+                        'name': skill.name,
+                        'category': skill.category,
+                        'description': skill.description,
+                        'source': skill.source,
+                        'installed_profiles': [],
+                        'updated_at': skill.updated_at,
+                    },
+                )
+                existing['installed_profiles'].append(context.profile)
+                if skill.updated_at and (existing['updated_at'] is None or skill.updated_at > existing['updated_at']):
+                    existing['updated_at'] = skill.updated_at
+                if not existing.get('description') and skill.description:
+                    existing['description'] = skill.description
+                if not existing.get('category') and skill.category:
+                    existing['category'] = skill.category
+        items = [
+            SystemSkillLibraryItem(
+                name=entry['name'],
+                category=entry.get('category'),
+                description=entry.get('description'),
+                source=entry.get('source'),
+                installed_profiles=sorted(set(entry['installed_profiles'])),
+                profile_count=len(set(entry['installed_profiles'])),
+                updated_at=entry.get('updated_at'),
+            )
+            for entry in aggregated.values()
+        ]
+        items.sort(key=lambda item: item.name)
+        return SystemSkillsLibraryResponse(skills=items, total=len(items))
+
+    def _find_skill(self, agent_id: str, skill_name: str) -> AgentSkill | None:
+        for skill_file in self._skill_files(agent_id):
+            if skill_file.parent.name == skill_name:
+                return self._scan_skill(agent_id, skill_file)
+        return None
+
+    def _skill_files(self, agent_id: str) -> list[Path]:
+        context = ensure_profile_exists(agent_id)
+        skills_root = context.home / 'skills'
+        if not skills_root.exists():
+            return []
+        return sorted(skills_root.glob('**/SKILL.md'), key=lambda path: path.parent.name)
+
+    def _registry_file(self, agent_id: str) -> Path:
+        context = ensure_profile_exists(agent_id)
+        return context.home / '.skills_registry.json'
+
+    def _load_registry(self, agent_id: str) -> dict[str, Any]:
+        payload = load_json_file(self._registry_file(agent_id))
+        return payload if isinstance(payload, dict) else {}
+
+    def _write_registry(self, agent_id: str, payload: dict[str, Any]) -> None:
+        path = self._registry_file(agent_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path: Path | None = None
+        try:
+            with NamedTemporaryFile('w', encoding='utf-8', dir=path.parent, delete=False) as handle:
+                json.dump(payload, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+                temp_path = Path(handle.name)
+            temp_path.replace(path)
+        finally:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink(missing_ok=True)
+
+    def _scan_skill(self, agent_id: str, skill_file: Path) -> AgentSkill:
+        registry = self._load_registry(agent_id)
+        rel = skill_file.relative_to(skill_file.parents[2])
+        parts = rel.parts
+        category = parts[0] if len(parts) >= 3 else None
+        description = self._extract_description(skill_file)
+        updated_at = datetime.fromtimestamp(skill_file.stat().st_mtime, tz=timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+        enabled = bool(registry.get(skill_file.parent.name, {}).get('enabled', True))
+        return AgentSkill(
+            name=skill_file.parent.name,
+            category=category,
+            description=description,
+            source='filesystem',
+            installed=True,
+            enabled=enabled,
+            updated_at=updated_at,
+        )
+
+    def _extract_description(self, skill_file: Path) -> str | None:
+        try:
+            lines = skill_file.read_text(encoding='utf-8').splitlines()
+        except OSError:
+            return None
+        for line in lines:
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#') or stripped == '---':
+                continue
+            return stripped
+        return None
+
+
+skill_service = SkillService()

--- a/api/tests/test_skills_api.py
+++ b/api/tests/test_skills_api.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def write_skill(root, category: str, name: str, body: str = '# Title\n\nSample description\n'):
+    skill_dir = root / 'skills' / category / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_file = skill_dir / 'SKILL.md'
+    skill_file.write_text(body, encoding='utf-8')
+    return skill_file
+
+
+def test_agent_skills_and_system_catalog_expose_stable_contracts(tmp_path, monkeypatch) -> None:
+    from app.services import skill_service as skill_service_module
+
+    write_skill(tmp_path, 'ops', 'incident-escalation', '# Incident\n\nCoordinate escalation paths.\n')
+    write_skill(tmp_path, 'ops', 'release-ops', '# Release\n\nAutomate release checks.\n')
+
+    ops_home = tmp_path / 'profiles' / 'ops'
+    write_skill(ops_home, 'ops', 'incident-escalation', '# Incident\n\nCoordinate escalation paths.\n')
+
+    monkeypatch.setattr(skill_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path if profile == 'default' else ops_home, profile=profile))
+    monkeypatch.setattr(skill_service_module, 'profile_contexts', lambda: [SimpleNamespace(home=tmp_path, profile='default'), SimpleNamespace(home=ops_home, profile='ops')])
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    list_response = client.get('/api/agents/default/skills')
+    assert list_response.status_code == 200
+    payload = list_response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['total'] == 2
+    assert payload['skills'][0]['name'] == 'incident-escalation'
+    assert payload['skills'][0]['installed'] is True
+    assert payload['skills'][0]['enabled'] is True
+    assert payload['skills'][0]['description'] == 'Coordinate escalation paths.'
+
+    detail_response = client.get('/api/agents/default/skills/incident-escalation')
+    assert detail_response.status_code == 200
+    detail = detail_response.json()
+    assert detail['name'] == 'incident-escalation'
+    assert detail['category'] == 'ops'
+    assert detail['source'] == 'filesystem'
+
+    catalog_response = client.get('/api/system/skills/catalog')
+    assert catalog_response.status_code == 200
+    catalog = catalog_response.json()
+    entry = next(item for item in catalog['skills'] if item['name'] == 'incident-escalation')
+    assert entry['installed_profiles'] == ['default', 'ops']
+    assert entry['profile_count'] == 2
+
+
+def test_agent_skill_patch_and_run_actions(tmp_path, monkeypatch) -> None:
+    from app.services import skill_service as skill_service_module
+
+    write_skill(tmp_path, 'ops', 'incident-escalation', '# Incident\n\nCoordinate escalation paths.\n')
+
+    monkeypatch.setattr(skill_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path, profile=profile))
+    monkeypatch.setattr(skill_service_module, 'profile_contexts', lambda: [SimpleNamespace(home=tmp_path, profile='default')])
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    patch_response = client.patch('/api/agents/default/skills/incident-escalation', json={'enabled': False})
+    assert patch_response.status_code == 200
+    patched = patch_response.json()
+    assert patched['enabled'] is False
+
+    persisted = client.get('/api/agents/default/skills/incident-escalation')
+    assert persisted.status_code == 200
+    assert persisted.json()['enabled'] is False
+
+    run_response = client.post('/api/agents/default/skills/incident-escalation/run')
+    assert run_response.status_code == 200
+    run = run_response.json()
+    assert run['agent_id'] == 'default'
+    assert run['skill_name'] == 'incident-escalation'
+    assert run['status'] == 'queued'
+    datetime.fromisoformat(run['requested_at'].replace('Z', '+00:00')).astimezone(timezone.utc)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -14,6 +14,7 @@ import {
   mockSkills,
   mockSystemAllowlists,
   mockSystemSecurity,
+  mockSystemSkillLibrary,
   mockTools,
   mockToolsets,
 } from './mockData'
@@ -37,6 +38,7 @@ import type {
   SkillBroadcastPayload,
   SystemAllowlistsRecord,
   SystemSecurityRecord,
+  SystemSkillLibraryRecord,
   ToggleSkillPayload,
   ToolRecord,
   ToolsetRecord,
@@ -81,16 +83,33 @@ type BackendStatusResponse = {
 }
 
 type BackendSkillsResponse = {
-  profile: string
+  profile?: string
+  agent_id?: string
   total: number
   skills: Array<{
     name: string
     category?: string | null
+    description?: string | null
     source?: string | null
     trust?: string | null
     enabled: boolean
+    installed?: boolean | null
     path?: string | null
+    updated_at?: string | null
   }>
+}
+
+type BackendSystemSkillsResponse = {
+  skills: Array<{
+    name: string
+    category?: string | null
+    description?: string | null
+    source?: string | null
+    installed_profiles: string[]
+    profile_count: number
+    updated_at?: string | null
+  }>
+  total: number
 }
 
 type BackendSessionsResponse = {
@@ -357,10 +376,25 @@ const normalizeSkills = (payload: BackendSkillsResponse, profileId: string): Ski
   payload.skills.map((skill) => ({
     id: skill.name,
     name: skill.name,
-    description: [skill.source, skill.trust].filter(Boolean).join(' · ') || skill.path || 'Filesystem skill',
+    description: skill.description ?? ([skill.source, skill.trust].filter(Boolean).join(' · ') || skill.path || 'Filesystem skill'),
     category: skill.category ?? 'uncategorized',
+    source: skill.source ?? undefined,
+    installed: skill.installed ?? true,
+    enabled: skill.enabled,
     enabledProfiles: skill.enabled ? [profileId] : [],
-    updatedAt: isoNow(),
+    installedProfiles: (skill.installed ?? true) ? [profileId] : [],
+    updatedAt: skill.updated_at ?? isoNow(),
+  }))
+
+const normalizeSystemSkillLibrary = (payload: BackendSystemSkillsResponse): SystemSkillLibraryRecord[] =>
+  payload.skills.map((skill) => ({
+    name: skill.name,
+    category: skill.category ?? 'uncategorized',
+    description: skill.description ?? 'Filesystem skill',
+    source: skill.source ?? undefined,
+    installedProfiles: skill.installed_profiles,
+    profileCount: skill.profile_count,
+    updatedAt: skill.updated_at ?? undefined,
   }))
 
 const normalizeSessions = (payload: BackendSessionsResponse): SessionRecord[] =>
@@ -674,26 +708,56 @@ export const apiClient = {
 
   getSkills: async (profileId: string): Promise<ApiResult<Skill[]>> =>
     withFallback(async () => {
-      const payload = await fetchJson<BackendSkillsResponse>(`/skills?profile=${encodeURIComponent(profileId)}`)
+      const payload = await fetchJson<BackendSkillsResponse>(`/agents/${encodeURIComponent(profileId)}/skills`)
       return normalizeSkills(payload, profileId)
-    }, cloneSkills),
+    }, () => cloneSkills().filter((skill) => skill.installedProfiles.includes(profileId))),
+
+  getSystemSkillLibrary: async (): Promise<ApiResult<SystemSkillLibraryRecord[]>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendSystemSkillsResponse>('/system/skills/catalog')
+      return normalizeSystemSkillLibrary(payload)
+    }, () => structuredClone(mockSystemSkillLibrary)),
 
   toggleSkill: async (profileId: string, skillId: string, payload: ToggleSkillPayload): Promise<ApiResult<Skill>> => {
-    await delay(150)
-    const baseSkill = cloneSkills().find((skill) => skill.id === skillId) ?? cloneSkills()[0]
-    const enabledProfiles = payload.enabled
-      ? Array.from(new Set([...baseSkill.enabledProfiles, profileId]))
-      : baseSkill.enabledProfiles.filter((item) => item !== profileId)
+    try {
+      const result = await fetchJson<BackendSkillsResponse['skills'][number]>(`/agents/${encodeURIComponent(profileId)}/skills/${encodeURIComponent(skillId)}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ enabled: payload.enabled }),
+      })
+      return {
+        data: normalizeSkills({ agent_id: profileId, total: 1, skills: [result] }, profileId)[0],
+        mock: false,
+      }
+    } catch (error) {
+      await delay(150)
+      const baseSkill = cloneSkills().find((skill) => skill.id === skillId) ?? cloneSkills()[0]
+      const enabledProfiles = payload.enabled
+        ? Array.from(new Set([...baseSkill.enabledProfiles, profileId]))
+        : baseSkill.enabledProfiles.filter((item) => item !== profileId)
+      const installedProfiles = baseSkill.installedProfiles.includes(profileId)
+        ? baseSkill.installedProfiles
+        : [...baseSkill.installedProfiles, profileId]
 
-    return {
-      data: {
-        ...baseSkill,
-        enabledProfiles,
-      },
-      mock: true,
-      error: 'Skill toggling is not wired to the backend yet; showing optimistic mock state.',
+      return {
+        data: {
+          ...baseSkill,
+          enabled: payload.enabled,
+          enabledProfiles,
+          installedProfiles,
+        },
+        mock: true,
+        error: error instanceof Error ? error.message : NETWORK_ERROR,
+      }
     }
   },
+
+  runSkill: async (profileId: string, skillId: string): Promise<ApiResult<{ status: string; message: string }>> =>
+    withFallback(async () => {
+      const result = await fetchJson<{ status: string; message: string }>(`/agents/${encodeURIComponent(profileId)}/skills/${encodeURIComponent(skillId)}/run`, {
+        method: 'POST',
+      })
+      return result
+    }, () => ({ status: 'queued', message: `Skill ${skillId} queued for execution on ${profileId}.` })),
 
   broadcastSkills: async (payload: SkillBroadcastPayload): Promise<ApiResult<{ synced: number }>> => {
     try {

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -14,6 +14,7 @@ import type {
   Skill,
   SystemAllowlistsRecord,
   SystemSecurityRecord,
+  SystemSkillLibraryRecord,
   ToolRecord,
   ToolsetRecord,
 } from '../types'
@@ -104,7 +105,11 @@ export const mockSkills: Skill[] = [
     name: 'Incident Escalation',
     description: 'Coordinate escalation paths and postmortem capture.',
     category: 'Operations',
+    source: 'filesystem',
+    installed: true,
+    enabled: true,
     enabledProfiles: ['default', 'ops'],
+    installedProfiles: ['default', 'ops'],
     updatedAt: '2026-04-23T07:10:00Z',
   },
   {
@@ -112,7 +117,11 @@ export const mockSkills: Skill[] = [
     name: 'Release Ops',
     description: 'Automate release train checks and rollback prompts.',
     category: 'Delivery',
+    source: 'filesystem',
+    installed: true,
+    enabled: true,
     enabledProfiles: ['default'],
+    installedProfiles: ['default'],
     updatedAt: '2026-04-23T06:40:00Z',
   },
   {
@@ -120,7 +129,11 @@ export const mockSkills: Skill[] = [
     name: 'Knowledge Scout',
     description: 'Summarize changed docs and sync context packs.',
     category: 'Research',
+    source: 'filesystem',
+    installed: true,
+    enabled: true,
     enabledProfiles: ['default', 'sandbox'],
+    installedProfiles: ['default', 'sandbox'],
     updatedAt: '2026-04-22T22:10:00Z',
   },
   {
@@ -128,10 +141,24 @@ export const mockSkills: Skill[] = [
     name: 'Session Curator',
     description: 'Archive stale sessions and annotate failures.',
     category: 'Maintenance',
+    source: 'filesystem',
+    installed: true,
+    enabled: true,
     enabledProfiles: ['ops', 'sandbox'],
+    installedProfiles: ['ops', 'sandbox'],
     updatedAt: '2026-04-22T20:00:00Z',
   },
 ]
+
+export const mockSystemSkillLibrary: SystemSkillLibraryRecord[] = mockSkills.map((skill) => ({
+  name: skill.id,
+  category: skill.category,
+  description: skill.description,
+  source: skill.source,
+  installedProfiles: skill.installedProfiles,
+  profileCount: skill.installedProfiles.length,
+  updatedAt: skill.updatedAt,
+}))
 
 export const mockSessions: SessionRecord[] = [
   {

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -1,31 +1,42 @@
-import { Button, Card, Col, Form, Row, Select, Space, Switch, Table, Tag, Typography, message } from 'antd'
+import { Button, Card, Col, Form, List, Row, Select, Space, Switch, Table, Tag, Typography, message } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { useMemo, useState } from 'react'
 import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
 import { PageHeader } from '../components/PageHeader'
 import { useProfileStore } from '../store/profileStore'
-import type { Skill, SkillBroadcastPayload } from '../types'
+import type { Skill, SkillBroadcastPayload, SystemSkillLibraryRecord } from '../types'
 
 export function SkillsPage() {
   const [form] = Form.useForm<SkillBroadcastPayload>()
   const [isBroadcasting, setIsBroadcasting] = useState(false)
+  const [runningSkillId, setRunningSkillId] = useState<string>()
   const { selectedProfileId } = useProfileStore()
   const profilesQuery = useApiQuery(apiClient.getProfiles, [])
   const activeProfileId = selectedProfileId ?? profilesQuery.data?.[0]?.id ?? 'default'
   const skillsQuery = useApiQuery(() => apiClient.getSkills(activeProfileId), [activeProfileId])
+  const libraryQuery = useApiQuery<SystemSkillLibraryRecord[]>(apiClient.getSystemSkillLibrary, [])
 
   const profileOptions = useMemo(
     () => (profilesQuery.data ?? []).map((profile) => ({ label: profile.name, value: profile.id })),
     [profilesQuery.data],
   )
-  const enabledCount = (skillsQuery.data ?? []).filter((skill) => skill.enabledProfiles.includes(activeProfileId)).length
+  const enabledCount = (skillsQuery.data ?? []).filter((skill) => skill.enabled).length
+  const installedCount = (skillsQuery.data ?? []).filter((skill) => skill.installed).length
   const broadcastTargets = Math.max(profileOptions.filter((profile) => profile.value !== activeProfileId).length, 0)
 
   const handleToggle = async (skill: Skill, enabled: boolean) => {
     const result = await apiClient.toggleSkill(activeProfileId, skill.id, { enabled })
     message.success(`${result.data.name} ${enabled ? 'enabled' : 'disabled'}${result.mock ? ' via mock API' : ''}.`)
     await skillsQuery.refresh()
+    await libraryQuery.refresh()
+  }
+
+  const handleRun = async (skill: Skill) => {
+    setRunningSkillId(skill.id)
+    const result = await apiClient.runSkill(activeProfileId, skill.id)
+    setRunningSkillId(undefined)
+    message.success(`${result.data.message}${result.mock ? ' (mocked)' : ''}`)
   }
 
   const handleBroadcast = async (values: SkillBroadcastPayload) => {
@@ -34,6 +45,7 @@ export function SkillsPage() {
     setIsBroadcasting(false)
     message.success(`Synced skills to ${result.data.synced} profile(s)${result.mock ? ' using mocked API flow' : ''}.`)
     form.resetFields()
+    await libraryQuery.refresh()
   }
 
   const columns: ColumnsType<Skill> = [
@@ -48,23 +60,18 @@ export function SkillsPage() {
       ),
     },
     { title: 'Category', dataIndex: 'category', render: (value) => <Tag color="purple">{value}</Tag> },
+    { title: 'Source', dataIndex: 'source', render: (value?: string) => value ?? 'filesystem' },
     {
       title: 'Enabled on active profile',
+      render: (_, skill) => <Switch checked={skill.enabled} onChange={(checked) => void handleToggle(skill, checked)} />,
+    },
+    {
+      title: 'Actions',
       render: (_, skill) => (
-        <Switch
-          checked={skill.enabledProfiles.includes(activeProfileId)}
-          onChange={(checked) => void handleToggle(skill, checked)}
-        />
+        <Button size="small" onClick={() => void handleRun(skill)} loading={runningSkillId === skill.id}>
+          Run
+        </Button>
       ),
-    },
-    {
-      title: 'Profiles',
-      render: (_, skill) => skill.enabledProfiles.map((profileId) => <Tag key={profileId}>{profileId}</Tag>),
-    },
-    {
-      title: 'Updated',
-      dataIndex: 'updatedAt',
-      render: (value) => new Date(value).toLocaleString(),
     },
   ]
 
@@ -72,70 +79,104 @@ export function SkillsPage() {
     <div className="page-stack">
       <PageHeader
         title="Skills"
-        description="Review skill coverage for the selected profile, toggle status, and broadcast configuration to target profiles."
-        mock={skillsQuery.isMock || profilesQuery.isMock}
-        error={skillsQuery.error ?? profilesQuery.error}
-        onRefresh={skillsQuery.refresh}
+        description="Manage profile-scoped installed skills, trigger skill runs, and browse the aggregated system skill library."
+        mock={skillsQuery.isMock || profilesQuery.isMock || libraryQuery.isMock}
+        error={skillsQuery.error ?? profilesQuery.error ?? libraryQuery.error}
+        onRefresh={async () => {
+          await skillsQuery.refresh()
+          await libraryQuery.refresh()
+        }}
       />
 
       <Row gutter={[16, 16]}>
         <Col xs={24} md={8}>
           <Card className="glass-panel qwen-summary-card">
-            <span className="qwen-summary-label">Catalog size</span>
-            <Typography.Title level={3}>{skillsQuery.data?.length ?? 0}</Typography.Title>
+            <span className="qwen-summary-label">Installed on active profile</span>
+            <Typography.Title level={3}>{installedCount}</Typography.Title>
           </Card>
         </Col>
         <Col xs={24} md={8}>
           <Card className="glass-panel qwen-summary-card">
-            <span className="qwen-summary-label">Enabled on active workspace</span>
+            <span className="qwen-summary-label">Enabled on active profile</span>
             <Typography.Title level={3}>{enabledCount}</Typography.Title>
           </Card>
         </Col>
         <Col xs={24} md={8}>
           <Card className="glass-panel qwen-summary-card">
-            <span className="qwen-summary-label">Broadcast targets</span>
-            <Typography.Title level={3}>{broadcastTargets}</Typography.Title>
+            <span className="qwen-summary-label">Global library size</span>
+            <Typography.Title level={3}>{libraryQuery.data?.length ?? 0}</Typography.Title>
           </Card>
         </Col>
       </Row>
 
       <Card className="glass-panel qwen-context-strip">
         <Space direction="vertical" size={2}>
-          <Typography.Text strong>Active workspace: {activeProfileId}</Typography.Text>
-          <Typography.Text type="secondary">Toggles apply to the workspace selected in the left navigation.</Typography.Text>
+          <Typography.Text strong>Active profile: {activeProfileId}</Typography.Text>
+          <Typography.Text type="secondary">Profile-scoped toggles write through the dashboard adapter instead of exposing raw skill file layout details.</Typography.Text>
         </Space>
       </Card>
 
       <Row gutter={[16, 16]}>
-        <Col xs={24} xl={16}>
-          <Card className="glass-panel qwen-section-card" title="Skill catalog">
+        <Col xs={24} xl={15}>
+          <Card className="glass-panel qwen-section-card" title="Installed skills">
             <Table rowKey="id" loading={skillsQuery.isLoading} dataSource={skillsQuery.data ?? []} columns={columns} pagination={false} />
           </Card>
         </Col>
-        <Col xs={24} xl={8}>
-          <Card className="glass-panel qwen-section-card" title="Broadcast skills">
-            <Typography.Paragraph className="qwen-card-description">
-              Copy enabled skills from the current workspace into one or more target workspaces.
-            </Typography.Paragraph>
-            <Form
-              form={form}
-              layout="vertical"
-              initialValues={{ sourceProfileId: activeProfileId }}
-              onFinish={(values) => void handleBroadcast(values)}
-            >
-              <Form.Item name="sourceProfileId" label="Source profile" rules={[{ required: true }]}>
-                <Select options={profileOptions} />
-              </Form.Item>
-              <Form.Item name="targetProfileIds" label="Target profiles" rules={[{ required: true, message: 'Choose at least one target profile' }]}>
-                <Select mode="multiple" options={profileOptions.filter((profile) => profile.value !== activeProfileId)} />
-              </Form.Item>
-              <Button type="primary" htmlType="submit" loading={isBroadcasting} block>
-                Broadcast enabled skills
-              </Button>
-            </Form>
+        <Col xs={24} xl={9}>
+          <Card className="glass-panel qwen-section-card" title="Global skill library" loading={libraryQuery.isLoading}>
+            <List
+              size="small"
+              dataSource={libraryQuery.data ?? []}
+              renderItem={(item) => (
+                <List.Item>
+                  <Space direction="vertical" size={2}>
+                    <Typography.Text strong>{item.name}</Typography.Text>
+                    <Typography.Text type="secondary">{item.description}</Typography.Text>
+                    <Space wrap>
+                      <Tag color="purple">{item.category}</Tag>
+                      <Tag>{item.profileCount} profile(s)</Tag>
+                      {item.installedProfiles.map((profileId) => <Tag key={`${item.name}-${profileId}`}>{profileId}</Tag>)}
+                    </Space>
+                  </Space>
+                </List.Item>
+              )}
+            />
           </Card>
         </Col>
       </Row>
+
+      <Card className="glass-panel qwen-section-card" title="Broadcast skills">
+        <Typography.Paragraph className="qwen-card-description">
+          Copy enabled skills from the current profile into one or more target profiles.
+        </Typography.Paragraph>
+        <Form
+          form={form}
+          layout="vertical"
+          initialValues={{ sourceProfileId: activeProfileId }}
+          onFinish={(values) => void handleBroadcast(values)}
+        >
+          <Row gutter={16}>
+            <Col xs={24} md={8}>
+              <Form.Item name="sourceProfileId" label="Source profile" rules={[{ required: true }]}>
+                <Select options={profileOptions} />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={12}>
+              <Form.Item name="targetProfileIds" label="Target profiles" rules={[{ required: true, message: 'Choose at least one target profile' }]}>
+                <Select mode="multiple" options={profileOptions.filter((profile) => profile.value !== activeProfileId)} />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={4}>
+              <Form.Item label=" ">
+                <Button type="primary" htmlType="submit" loading={isBroadcasting} block>
+                  Broadcast
+                </Button>
+              </Form.Item>
+            </Col>
+          </Row>
+        </Form>
+        <Typography.Text type="secondary">Available targets: {broadcastTargets}</Typography.Text>
+      </Card>
     </div>
   )
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -52,8 +52,22 @@ export interface Skill {
   name: string
   description: string
   category: string
+  source?: string
+  installed: boolean
+  enabled: boolean
   enabledProfiles: string[]
+  installedProfiles: string[]
   updatedAt: string
+}
+
+export interface SystemSkillLibraryRecord {
+  name: string
+  category: string
+  description: string
+  source?: string
+  installedProfiles: string[]
+  profileCount: number
+  updatedAt?: string
 }
 
 export interface ToggleSkillPayload {


### PR DESCRIPTION
## Summary
- add stable agent-scoped skill contracts plus a dedicated skill service
- expose skill detail/update/run endpoints and system skill library/catalog endpoints
- update the Skills page to manage installed skills on the active profile and browse the aggregated global library

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_skills_api.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build

Closes #11
