### PR TITLE
feat: add mcp registry contracts

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -19,6 +19,7 @@ from app.models import (
     AgentCronJobsResponse,
     AgentDefaults,
     AgentFiles,
+    AgentMcpServersResponse,
     AgentRuntimeCollection,
     AgentRuntimeHints,
     AgentRuntimeSummary,
@@ -36,6 +37,8 @@ from app.models import (
     CreateProfileRequest,
     HealthResponse,
     LogEntry,
+    McpReloadResponse,
+    McpServerInfo,
     ModelCatalogResponse,
     ProviderCatalogResponse,
     ProviderRoutingPatchRequest,
@@ -51,6 +54,7 @@ from app.models import (
     StatusResponse,
     SystemAllowlistsResponse,
     SystemHealthResponse,
+    SystemMcpServersResponse,
     SystemSecurityResponse,
     SystemSkillsLibraryResponse,
     SystemVersionResponse,
@@ -75,6 +79,7 @@ from app.services.hermes_adapter import (
 )
 from app.services.config_service import config_service
 from app.services.cron_service import cron_service
+from app.services.mcp_service import mcp_service
 from app.services.provider_service import provider_service
 from app.services.run_service import run_service
 from app.services.runtime_registry import runtime_registry
@@ -171,6 +176,11 @@ def get_system_toolsets() -> ToolsetResponse:
 @app.get('/api/system/tools', response_model=ToolCatalogResponse, tags=['system'])
 def get_system_tools() -> ToolCatalogResponse:
     return tool_service.list_system_tools()
+
+
+@app.get('/api/system/mcp/servers', response_model=SystemMcpServersResponse, tags=['mcp'])
+def get_system_mcp_servers() -> SystemMcpServersResponse:
+    return mcp_service.list_system_servers()
 
 
 @app.get('/api/system/security', response_model=SystemSecurityResponse, tags=['system'])
@@ -290,6 +300,36 @@ def patch_agent_toolsets(agent_id: str, payload: ToolsetPatchRequest) -> Toolset
 def list_agent_tools(agent_id: str) -> ToolCatalogResponse:
     ensure_profile_exists(agent_id)
     return tool_service.list_agent_tools(agent_id)
+
+
+@app.get('/api/agents/{agent_id}/mcp/servers', response_model=AgentMcpServersResponse, tags=['mcp'])
+def list_agent_mcp_servers(agent_id: str) -> AgentMcpServersResponse:
+    ensure_profile_exists(agent_id)
+    return mcp_service.list_agent_servers(agent_id)
+
+
+@app.get('/api/agents/{agent_id}/mcp/tools', response_model=ToolCatalogResponse, tags=['mcp'])
+def list_agent_mcp_tools(agent_id: str) -> ToolCatalogResponse:
+    ensure_profile_exists(agent_id)
+    return mcp_service.list_agent_tools(agent_id)
+
+
+@app.post('/api/agents/{agent_id}/mcp/reload', response_model=McpReloadResponse, tags=['mcp'])
+def reload_agent_mcp_servers(agent_id: str) -> McpReloadResponse:
+    ensure_profile_exists(agent_id)
+    return mcp_service.reload_agent_servers(agent_id)
+
+
+@app.post('/api/agents/{agent_id}/mcp/{server_id}/connect', response_model=McpServerInfo, tags=['mcp'])
+def connect_agent_mcp_server(agent_id: str, server_id: str) -> McpServerInfo:
+    ensure_profile_exists(agent_id)
+    return mcp_service.connect_server(agent_id, server_id)
+
+
+@app.post('/api/agents/{agent_id}/mcp/{server_id}/disconnect', response_model=McpServerInfo, tags=['mcp'])
+def disconnect_agent_mcp_server(agent_id: str, server_id: str) -> McpServerInfo:
+    ensure_profile_exists(agent_id)
+    return mcp_service.disconnect_server(agent_id, server_id)
 
 
 @app.get('/api/agents/{agent_id}/approvals', response_model=ApprovalQueueResponse, tags=['security'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -385,6 +385,37 @@ class ToolCatalogResponse(BaseModel):
     total: int
 
 
+class McpServerInfo(BaseModel):
+    id: str
+    name: str
+    transport: str
+    enabled: bool = True
+    connection_state: str = 'configured'
+    auth_state: str = 'none'
+    discovered_tools_count: int = 0
+    last_reload_at: str | None = None
+    sampling_enabled: bool = True
+    profiles: list[str] = Field(default_factory=list)
+
+
+class AgentMcpServersResponse(BaseModel):
+    agent_id: str
+    servers: list[McpServerInfo]
+    total: int
+
+
+class SystemMcpServersResponse(BaseModel):
+    servers: list[McpServerInfo]
+    total: int
+
+
+class McpReloadResponse(BaseModel):
+    agent_id: str
+    reloaded: bool
+    server_count: int
+    message: str
+
+
 class ApprovalRequest(BaseModel):
     id: str
     agent_id: str

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,3 +1,3 @@
-from . import config_service, cron_service, provider_service, security_service, session_service, skill_service, tool_service
+from . import config_service, cron_service, mcp_service, provider_service, security_service, session_service, skill_service, tool_service
 
-__all__ = ["config_service", "cron_service", "provider_service", "security_service", "session_service", "skill_service", "tool_service"]
+__all__ = ["config_service", "cron_service", "mcp_service", "provider_service", "security_service", "session_service", "skill_service", "tool_service"]

--- a/api/app/services/mcp_service.py
+++ b/api/app/services/mcp_service.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from threading import RLock
+from typing import Any
+
+from fastapi import HTTPException
+
+from app.models import AgentMcpServersResponse, McpReloadResponse, McpServerInfo, SystemMcpServersResponse, ToolCatalogResponse, ToolInfo
+from app.services.hermes_adapter import ensure_profile_exists, profile_contexts
+from app.utils import load_json_file, load_yaml_file
+
+_WRITE_LOCK = RLock()
+
+
+class McpService:
+    def list_agent_servers(self, agent_id: str) -> AgentMcpServersResponse:
+        servers = self._resolve_servers(agent_id)
+        return AgentMcpServersResponse(agent_id=agent_id, servers=servers, total=len(servers))
+
+    def list_agent_tools(self, agent_id: str) -> ToolCatalogResponse:
+        servers = self._resolve_servers(agent_id)
+        tools = [
+            ToolInfo(
+                name=f'mcp__{server.id}',
+                toolset=f'mcp:{server.id}',
+                source_type='mcp',
+                source_id=server.id,
+                available=server.connection_state != 'disconnected',
+                availability_reason='MCP server configured',
+                schema_summary={'type': 'mcp', 'transport': server.transport, 'sampling_enabled': server.sampling_enabled},
+            )
+            for server in servers
+        ]
+        return ToolCatalogResponse(agent_id=agent_id, tools=tools, total=len(tools))
+
+    def reload_agent_servers(self, agent_id: str) -> McpReloadResponse:
+        servers = self._resolve_servers(agent_id)
+        registry = self._load_registry(agent_id)
+        now = self._iso_now()
+        for server in servers:
+            state = registry.setdefault(server.id, {})
+            state['last_reload_at'] = now
+            state.setdefault('connection_state', 'configured')
+        self._write_registry(agent_id, registry)
+        return McpReloadResponse(
+            agent_id=agent_id,
+            reloaded=True,
+            server_count=len(servers),
+            message=f'Reloaded {len(servers)} MCP server definitions for {agent_id}.',
+        )
+
+    def connect_server(self, agent_id: str, server_id: str) -> McpServerInfo:
+        return self._update_connection_state(agent_id, server_id, 'connected')
+
+    def disconnect_server(self, agent_id: str, server_id: str) -> McpServerInfo:
+        return self._update_connection_state(agent_id, server_id, 'disconnected')
+
+    def list_system_servers(self) -> SystemMcpServersResponse:
+        aggregated: dict[str, McpServerInfo] = {}
+        for context in profile_contexts():
+            for server in self._resolve_servers(context.profile):
+                existing = aggregated.get(server.id)
+                if existing is None:
+                    aggregated[server.id] = server.model_copy(update={'profiles': [context.profile]})
+                    continue
+                profiles = sorted(set([*existing.profiles, context.profile]))
+                connection_state = existing.connection_state
+                if server.connection_state == 'connected' or existing.connection_state == 'connected':
+                    connection_state = 'connected'
+                elif server.connection_state == 'configured' and existing.connection_state == 'disconnected':
+                    connection_state = 'configured'
+                aggregated[server.id] = existing.model_copy(
+                    update={
+                        'profiles': profiles,
+                        'connection_state': connection_state,
+                        'discovered_tools_count': max(existing.discovered_tools_count, server.discovered_tools_count),
+                        'last_reload_at': max(filter(None, [existing.last_reload_at, server.last_reload_at]), default=None),
+                    }
+                )
+        servers = [aggregated[key] for key in sorted(aggregated)]
+        return SystemMcpServersResponse(servers=servers, total=len(servers))
+
+    def _update_connection_state(self, agent_id: str, server_id: str, state: str) -> McpServerInfo:
+        servers = {server.id: server for server in self._resolve_servers(agent_id)}
+        if server_id not in servers:
+            raise HTTPException(status_code=404, detail=f'MCP server {server_id} not found')
+        registry = self._load_registry(agent_id)
+        entry = registry.setdefault(server_id, {})
+        entry['connection_state'] = state
+        entry['last_reload_at'] = self._iso_now()
+        self._write_registry(agent_id, registry)
+        return self._resolve_server(agent_id, server_id)
+
+    def _resolve_servers(self, agent_id: str) -> list[McpServerInfo]:
+        context = ensure_profile_exists(agent_id)
+        config = load_yaml_file(context.home / 'config.yaml')
+        servers = config.get('mcp_servers') if isinstance(config.get('mcp_servers'), dict) else {}
+        registry = self._load_registry(agent_id)
+        return [self._server_info(server_id, payload, registry.get(server_id, {})) for server_id, payload in sorted(servers.items()) if isinstance(payload, dict)]
+
+    def _resolve_server(self, agent_id: str, server_id: str) -> McpServerInfo:
+        for server in self._resolve_servers(agent_id):
+            if server.id == server_id:
+                return server
+        raise HTTPException(status_code=404, detail=f'MCP server {server_id} not found')
+
+    def _server_info(self, server_id: str, payload: dict[str, Any], state: dict[str, Any]) -> McpServerInfo:
+        transport = 'http' if payload.get('url') else 'stdio'
+        auth_state = 'configured' if self._has_auth(payload) else 'none'
+        sampling = payload.get('sampling') if isinstance(payload.get('sampling'), dict) else {}
+        sampling_enabled = sampling.get('enabled', True)
+        return McpServerInfo(
+            id=server_id,
+            name=server_id,
+            transport=transport,
+            enabled=bool(payload.get('enabled', True)),
+            connection_state=str(state.get('connection_state') or 'configured'),
+            auth_state=auth_state,
+            discovered_tools_count=1,
+            last_reload_at=state.get('last_reload_at'),
+            sampling_enabled=bool(sampling_enabled),
+        )
+
+    def _has_auth(self, payload: dict[str, Any]) -> bool:
+        env = payload.get('env')
+        headers = payload.get('headers')
+        if isinstance(env, dict) and bool(env):
+            return True
+        if isinstance(headers, dict) and bool(headers):
+            return True
+        return False
+
+    def _registry_file(self, agent_id: str) -> Path:
+        context = ensure_profile_exists(agent_id)
+        return context.home / '.mcp_registry.json'
+
+    def _load_registry(self, agent_id: str) -> dict[str, Any]:
+        payload = load_json_file(self._registry_file(agent_id))
+        return payload if isinstance(payload, dict) else {}
+
+    def _write_registry(self, agent_id: str, payload: dict[str, Any]) -> None:
+        path = self._registry_file(agent_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path: Path | None = None
+        try:
+            with NamedTemporaryFile('w', encoding='utf-8', dir=path.parent, delete=False) as handle:
+                json.dump(payload, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+                temp_path = Path(handle.name)
+            temp_path.replace(path)
+        finally:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink(missing_ok=True)
+
+    def _iso_now(self) -> str:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+mcp_service = McpService()

--- a/api/tests/test_mcp_api.py
+++ b/api/tests/test_mcp_api.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+
+import yaml
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def write_config(path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
+
+
+def test_agent_mcp_servers_and_tools_expose_stable_contracts(tmp_path, monkeypatch) -> None:
+    from app.services import mcp_service as mcp_service_module
+
+    write_config(
+        tmp_path / 'config.yaml',
+        {
+            'mcp_servers': {
+                'mempalace': {
+                    'command': '/usr/bin/python3',
+                    'args': ['-m', 'mempalace.server'],
+                    'env': {'MEMPALACE_TOKEN': 'secret'},
+                    'sampling': {'enabled': False},
+                },
+                'notion': {
+                    'url': 'https://mcp.example.com/notion',
+                    'headers': {'Authorization': 'Bearer token'},
+                },
+            }
+        },
+    )
+
+    monkeypatch.setattr(mcp_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path, profile=profile))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    servers_response = client.get('/api/agents/default/mcp/servers')
+    assert servers_response.status_code == 200
+    payload = servers_response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['total'] == 2
+    assert [item['id'] for item in payload['servers']] == ['mempalace', 'notion']
+    assert payload['servers'][0]['transport'] == 'stdio'
+    assert payload['servers'][0]['connection_state'] == 'configured'
+    assert payload['servers'][0]['auth_state'] == 'configured'
+    assert payload['servers'][0]['discovered_tools_count'] == 1
+    assert payload['servers'][0]['sampling_enabled'] is False
+    assert payload['servers'][1]['transport'] == 'http'
+
+    tools_response = client.get('/api/agents/default/mcp/tools')
+    assert tools_response.status_code == 200
+    tools_payload = tools_response.json()
+    assert tools_payload['agent_id'] == 'default'
+    assert tools_payload['total'] == 2
+    first_tool = tools_payload['tools'][0]
+    assert first_tool['name'] == 'mcp__mempalace'
+    assert first_tool['source_type'] == 'mcp'
+    assert first_tool['source_id'] == 'mempalace'
+    assert first_tool['availability_reason'] == 'MCP server configured'
+
+
+def test_agent_mcp_actions_update_server_state(tmp_path, monkeypatch) -> None:
+    from app.services import mcp_service as mcp_service_module
+
+    write_config(tmp_path / 'config.yaml', {'mcp_servers': {'mempalace': {'command': '/usr/bin/python3'}}})
+
+    monkeypatch.setattr(mcp_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=tmp_path, profile=profile))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    connect_response = client.post('/api/agents/default/mcp/mempalace/connect')
+    assert connect_response.status_code == 200
+    assert connect_response.json()['connection_state'] == 'connected'
+
+    disconnect_response = client.post('/api/agents/default/mcp/mempalace/disconnect')
+    assert disconnect_response.status_code == 200
+    assert disconnect_response.json()['connection_state'] == 'disconnected'
+
+    reload_response = client.post('/api/agents/default/mcp/reload')
+    assert reload_response.status_code == 200
+    reload_payload = reload_response.json()
+    assert reload_payload['agent_id'] == 'default'
+    assert reload_payload['reloaded'] is True
+    assert reload_payload['server_count'] == 1
+
+
+def test_system_mcp_registry_aggregates_profiles(tmp_path, monkeypatch) -> None:
+    from app.services import mcp_service as mcp_service_module
+
+    default_home = tmp_path / 'default'
+    ops_home = tmp_path / 'ops'
+    write_config(default_home / 'config.yaml', {'mcp_servers': {'mempalace': {'command': '/usr/bin/python3'}}})
+    write_config(ops_home / 'config.yaml', {'mcp_servers': {'notion': {'url': 'https://mcp.example.com/notion'}}})
+
+    monkeypatch.setattr(mcp_service_module, 'ensure_profile_exists', lambda profile='default': SimpleNamespace(home=default_home if profile == 'default' else ops_home, profile=profile))
+    monkeypatch.setattr(mcp_service_module, 'profile_contexts', lambda: [SimpleNamespace(home=default_home, profile='default'), SimpleNamespace(home=ops_home, profile='ops')])
+
+    response = client.get('/api/system/mcp/servers')
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['total'] == 2
+    by_id = {item['id']: item for item in payload['servers']}
+    assert by_id['mempalace']['profiles'] == ['default']
+    assert by_id['notion']['profiles'] == ['ops']

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { ConfigPage } from './pages/ConfigPage'
 import { ConsolePage } from './pages/ConsolePage'
 import { CronJobsPage } from './pages/CronJobsPage'
 import { LogsPage } from './pages/LogsPage'
+import { McpPage } from './pages/McpPage'
 import { OverviewPage } from './pages/OverviewPage'
 import { ProfilesPage } from './pages/ProfilesPage'
 import { ProvidersPage } from './pages/ProvidersPage'
@@ -22,6 +23,7 @@ function App() {
         <Route path="/profiles" element={<ProfilesPage />} />
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/tools" element={<ToolsPage />} />
+        <Route path="/mcp" element={<McpPage />} />
         <Route path="/security" element={<SecurityPage />} />
         <Route path="/sessions" element={<SessionsPage />} />
         <Route path="/config" element={<ConfigPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4,6 +4,7 @@ import {
   mockApprovals,
   mockCronJobs,
   mockLogs,
+  mockMcpServers,
   mockModels,
   mockOverview,
   mockProfiles,
@@ -26,6 +27,7 @@ import type {
   CreateProfilePayload,
   CronJob,
   LogEntry,
+  McpServerRecord,
   ModelCatalogRecord,
   OverviewResponse,
   Profile,
@@ -267,6 +269,23 @@ type BackendToolsResponse = {
     available: boolean
     availability_reason?: string | null
     schema_summary: Record<string, unknown>
+  }>
+  total: number
+}
+
+type BackendMcpServersResponse = {
+  agent_id?: string
+  servers: Array<{
+    id: string
+    name: string
+    transport: 'stdio' | 'http'
+    enabled: boolean
+    connection_state: string
+    auth_state: string
+    discovered_tools_count: number
+    last_reload_at?: string | null
+    sampling_enabled: boolean
+    profiles?: string[]
   }>
   total: number
 }
@@ -546,6 +565,20 @@ const normalizeTools = (payload: BackendToolsResponse): ToolRecord[] =>
     available: tool.available,
     availabilityReason: tool.availability_reason ?? undefined,
     schemaSummary: tool.schema_summary,
+  }))
+
+const normalizeMcpServers = (payload: BackendMcpServersResponse): McpServerRecord[] =>
+  payload.servers.map((server) => ({
+    id: server.id,
+    name: server.name,
+    transport: server.transport,
+    enabled: server.enabled,
+    connectionState: server.connection_state,
+    authState: server.auth_state,
+    discoveredToolsCount: server.discovered_tools_count,
+    lastReloadAt: server.last_reload_at ?? undefined,
+    samplingEnabled: server.sampling_enabled,
+    profiles: server.profiles ?? (payload.agent_id ? [payload.agent_id] : []),
   }))
 
 const normalizeApprovals = (payload: BackendApprovalsResponse): ApprovalRecord[] =>
@@ -910,6 +943,43 @@ export const apiClient = {
       const payload = await fetchJson<BackendToolsResponse>(`/agents/${encodeURIComponent(profileId)}/tools`)
       return normalizeTools(payload)
     }, () => structuredClone(mockTools)),
+
+  getAgentMcpServers: async (profileId: string): Promise<ApiResult<McpServerRecord[]>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendMcpServersResponse>(`/agents/${encodeURIComponent(profileId)}/mcp/servers`)
+      return normalizeMcpServers(payload)
+    }, () => structuredClone(mockMcpServers).filter((server) => server.profiles.includes(profileId))),
+
+  getAgentMcpTools: async (profileId: string): Promise<ApiResult<ToolRecord[]>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendToolsResponse>(`/agents/${encodeURIComponent(profileId)}/mcp/tools`)
+      return normalizeTools(payload)
+    }, () => structuredClone(mockTools).filter((tool) => tool.sourceType === 'mcp')),
+
+  getSystemMcpServers: async (): Promise<ApiResult<McpServerRecord[]>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendMcpServersResponse>('/system/mcp/servers')
+      return normalizeMcpServers(payload)
+    }, () => structuredClone(mockMcpServers)),
+
+  reloadAgentMcpServers: async (profileId: string): Promise<ApiResult<{ reloaded: boolean; serverCount: number; message: string }>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<{ reloaded: boolean; server_count: number; message: string }>(`/agents/${encodeURIComponent(profileId)}/mcp/reload`, {
+        method: 'POST',
+      })
+      return { reloaded: payload.reloaded, serverCount: payload.server_count, message: payload.message }
+    }, () => ({ reloaded: true, serverCount: structuredClone(mockMcpServers).filter((server) => server.profiles.includes(profileId)).length, message: `Reloaded MCP server definitions for ${profileId}.` })),
+
+  setAgentMcpConnection: async (profileId: string, serverId: string, connected: boolean): Promise<ApiResult<McpServerRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendMcpServersResponse['servers'][number]>(`/agents/${encodeURIComponent(profileId)}/mcp/${encodeURIComponent(serverId)}/${connected ? 'connect' : 'disconnect'}`, {
+        method: 'POST',
+      })
+      return normalizeMcpServers({ agent_id: profileId, servers: [payload], total: 1 })[0]
+    }, () => {
+      const base = structuredClone(mockMcpServers).find((server) => server.id === serverId) ?? structuredClone(mockMcpServers)[0]
+      return { ...base, connectionState: connected ? 'connected' : 'disconnected' }
+    }),
 
   getAgentApprovals: async (profileId: string): Promise<ApiResult<ApprovalRecord[]>> =>
     withFallback(async () => {

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -4,6 +4,7 @@ import type {
   ApprovalRecord,
   CronJob,
   LogEntry,
+  McpServerRecord,
   ModelCatalogRecord,
   OverviewResponse,
   Profile,
@@ -332,19 +333,19 @@ export const mockToolsets: ToolsetRecord[] = [
 
 export const mockTools: ToolRecord[] = [
   {
-    name: 'browser_navigate',
-    toolset: 'browser',
+    name: 'terminal',
+    toolset: 'hermes-cli',
     sourceType: 'builtin',
-    sourceId: 'browser',
+    sourceId: 'hermes-cli',
     available: true,
     availabilityReason: 'Enabled by configured toolset',
     schemaSummary: { type: 'builtin' },
   },
   {
-    name: 'terminal',
-    toolset: 'hermes-cli',
+    name: 'browser_navigate',
+    toolset: 'browser',
     sourceType: 'builtin',
-    sourceId: 'hermes-cli',
+    sourceId: 'browser',
     available: true,
     availabilityReason: 'Enabled by configured toolset',
     schemaSummary: { type: 'builtin' },
@@ -356,7 +357,34 @@ export const mockTools: ToolRecord[] = [
     sourceId: 'mempalace',
     available: true,
     availabilityReason: 'MCP server configured',
-    schemaSummary: { type: 'mcp' },
+    schemaSummary: { type: 'mcp', transport: 'stdio' },
+  },
+]
+
+export const mockMcpServers: McpServerRecord[] = [
+  {
+    id: 'mempalace',
+    name: 'mempalace',
+    transport: 'stdio',
+    enabled: true,
+    connectionState: 'connected',
+    authState: 'configured',
+    discoveredToolsCount: 1,
+    lastReloadAt: '2026-04-24T03:30:00Z',
+    samplingEnabled: false,
+    profiles: ['default', 'ops'],
+  },
+  {
+    id: 'notion',
+    name: 'notion',
+    transport: 'http',
+    enabled: true,
+    connectionState: 'configured',
+    authState: 'configured',
+    discoveredToolsCount: 1,
+    lastReloadAt: '2026-04-24T03:20:00Z',
+    samplingEnabled: true,
+    profiles: ['default'],
   },
 ]
 

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -1,4 +1,5 @@
 import {
+  ApiOutlined,
   ClockCircleOutlined,
   ConsoleSqlOutlined,
   FileTextOutlined,
@@ -26,6 +27,7 @@ const navigationItems: MenuProps['items'] = [
       { key: '/console', icon: <ConsoleSqlOutlined />, label: 'Console' },
       { key: '/sessions', icon: <RadarChartOutlined />, label: 'Sessions' },
       { key: '/tools', icon: <ToolOutlined />, label: 'Tools' },
+      { key: '/mcp', icon: <ApiOutlined />, label: 'MCP' },
       { key: '/security', icon: <SafetyCertificateOutlined />, label: 'Security' },
       { key: '/cron-jobs', icon: <ClockCircleOutlined />, label: 'Cron Jobs' },
       { key: '/logs', icon: <FileTextOutlined />, label: 'Logs' },

--- a/web/src/pages/McpPage.tsx
+++ b/web/src/pages/McpPage.tsx
@@ -1,0 +1,142 @@
+import { Button, Card, Col, List, Row, Space, Table, Tag, Typography, message } from 'antd'
+import type { ColumnsType } from 'antd/es/table'
+import { apiClient } from '../api/client'
+import { useApiQuery } from '../api/hooks'
+import { PageHeader } from '../components/PageHeader'
+import { useProfileStore } from '../store/profileStore'
+import type { McpServerRecord, ToolRecord } from '../types'
+
+const serverColumns: ColumnsType<McpServerRecord> = [
+  { title: 'Server', dataIndex: 'name' },
+  { title: 'Transport', dataIndex: 'transport', render: (value) => <Tag color={value === 'http' ? 'cyan' : 'purple'}>{value}</Tag> },
+  { title: 'Connection', dataIndex: 'connectionState', render: (value) => <Tag color={value === 'connected' ? 'green' : value === 'disconnected' ? 'default' : 'gold'}>{value}</Tag> },
+  { title: 'Auth', dataIndex: 'authState', render: (value) => <Tag>{value}</Tag> },
+  { title: 'Discovered tools', dataIndex: 'discoveredToolsCount' },
+]
+
+const toolColumns: ColumnsType<ToolRecord> = [
+  { title: 'Injected tool', dataIndex: 'name' },
+  { title: 'Server', dataIndex: 'sourceId' },
+  { title: 'Availability', dataIndex: 'available', render: (value: boolean) => <Tag color={value ? 'green' : 'red'}>{value ? 'Available' : 'Unavailable'}</Tag> },
+]
+
+export function McpPage() {
+  const { selectedProfileId } = useProfileStore()
+  const profileId = selectedProfileId ?? 'default'
+  const serversQuery = useApiQuery<McpServerRecord[]>(() => apiClient.getAgentMcpServers(profileId), [profileId])
+  const toolsQuery = useApiQuery<ToolRecord[]>(() => apiClient.getAgentMcpTools(profileId), [profileId])
+  const systemQuery = useApiQuery<McpServerRecord[]>(apiClient.getSystemMcpServers, [])
+
+  const isMock = serversQuery.isMock || toolsQuery.isMock || systemQuery.isMock
+  const error = serversQuery.error ?? toolsQuery.error ?? systemQuery.error
+
+  const handleReload = async () => {
+    const result = await apiClient.reloadAgentMcpServers(profileId)
+    message.success(`${result.data.message}${result.mock ? ' (mocked)' : ''}`)
+    await serversQuery.refresh()
+    await toolsQuery.refresh()
+    await systemQuery.refresh()
+  }
+
+  const handleToggleConnection = async (server: McpServerRecord) => {
+    const nextConnected = server.connectionState !== 'connected'
+    const result = await apiClient.setAgentMcpConnection(profileId, server.id, nextConnected)
+    message.success(`${result.data.name} ${nextConnected ? 'connected' : 'disconnected'}${result.mock ? ' (mocked)' : ''}.`)
+    await serversQuery.refresh()
+    await systemQuery.refresh()
+  }
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="MCP"
+        description="Inspect profile-scoped MCP server registry, connection state, and injected tool visibility through the dashboard adapter boundary."
+        mock={isMock}
+        error={error}
+        onRefresh={async () => {
+          await serversQuery.refresh()
+          await toolsQuery.refresh()
+          await systemQuery.refresh()
+        }}
+      />
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Current profile</span>
+            <Typography.Title level={3}>{profileId}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Configured servers</span>
+            <Typography.Title level={3}>{serversQuery.data?.length ?? 0}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Injected MCP tools</span>
+            <Typography.Title level={3}>{toolsQuery.data?.length ?? 0}</Typography.Title>
+          </Card>
+        </Col>
+      </Row>
+
+      <Card className="glass-panel qwen-context-strip">
+        <Space align="center" wrap>
+          <Typography.Text strong>Reload discovery registry for {profileId}</Typography.Text>
+          <Button onClick={() => void handleReload()}>Reload MCP</Button>
+        </Space>
+      </Card>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={14}>
+          <Card className="glass-panel qwen-section-card" title="Profile MCP servers" loading={serversQuery.isLoading}>
+            <Table
+              rowKey="id"
+              columns={serverColumns}
+              dataSource={serversQuery.data ?? []}
+              pagination={false}
+              expandable={{
+                expandedRowRender: (record) => (
+                  <Space direction="vertical" size={6}>
+                    <Typography.Text>Profiles: {record.profiles.join(', ') || '—'}</Typography.Text>
+                    <Typography.Text>Last reload: {record.lastReloadAt ?? '—'}</Typography.Text>
+                    <Typography.Text>Sampling enabled: {record.samplingEnabled ? 'yes' : 'no'}</Typography.Text>
+                    <Button size="small" onClick={() => void handleToggleConnection(record)}>
+                      {record.connectionState === 'connected' ? 'Disconnect' : 'Connect'}
+                    </Button>
+                  </Space>
+                ),
+              }}
+            />
+          </Card>
+        </Col>
+        <Col xs={24} xl={10}>
+          <Card className="glass-panel qwen-section-card" title="Injected MCP tools" loading={toolsQuery.isLoading}>
+            <Table rowKey="name" columns={toolColumns} dataSource={toolsQuery.data ?? []} pagination={false} />
+          </Card>
+        </Col>
+      </Row>
+
+      <Card className="glass-panel qwen-section-card" title="System MCP registry" loading={systemQuery.isLoading}>
+        <List
+          dataSource={systemQuery.data ?? []}
+          renderItem={(server) => (
+            <List.Item>
+              <List.Item.Meta
+                title={`${server.name} · ${server.transport}`}
+                description={
+                  <Space direction="vertical" size={4}>
+                    <Typography.Text>Profiles: {server.profiles.join(', ') || '—'}</Typography.Text>
+                    <Typography.Text type="secondary">Connection: {server.connectionState} · Auth: {server.authState}</Typography.Text>
+                  </Space>
+                }
+              />
+              <Tag>{server.discoveredToolsCount} tools</Tag>
+            </List.Item>
+          )}
+        />
+      </Card>
+    </div>
+  )
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -189,6 +189,19 @@ export interface ToolRecord {
   schemaSummary: Record<string, unknown>
 }
 
+export interface McpServerRecord {
+  id: string
+  name: string
+  transport: 'stdio' | 'http'
+  enabled: boolean
+  connectionState: string
+  authState: string
+  discoveredToolsCount: number
+  lastReloadAt?: string
+  samplingEnabled: boolean
+  profiles: string[]
+}
+
 export interface ApprovalRecord {
   id: string
   agentId: string


### PR DESCRIPTION
## Summary
- add stable agent-scoped MCP registry contracts plus a dedicated MCP service
- expose MCP server listing, injected tool visibility, reload, and connect/disconnect actions through the dashboard adapter
- add an MCP page for profile-scoped server state and system-wide registry visibility

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_mcp_api.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build

Closes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP management interface enabling users to view, connect, disconnect, and reload MCP servers
  * Integrated system-wide MCP server registry visibility across profiles
  * Added MCP tools discovery and availability tracking for agents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->