### PR TITLE
feat: add diagnostics and system health contracts

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -35,6 +35,7 @@ from app.models import (
     AgentSessionsResponse,
     AgentSummary,
     AgentCheckpointsResponse,
+    AgentDiagnosticsResponse,
     AgentWorkspaceArtifactsResponse,
     AgentWorkspaceTreeResponse,
     ApprovalQueueResponse,
@@ -42,6 +43,8 @@ from app.models import (
     ConfigSummary,
     CreateProfileRequest,
     HealthResponse,
+    DiagnosticsCheck,
+    DiagnosticsRuntimeSummary,
     GatewayLifecycleResponse,
     GatewayPlatformInfo,
     LogEntry,
@@ -63,9 +66,12 @@ from app.models import (
     SessionSearchResponse,
     SkillBroadcastRequest,
     SkillBroadcastResult,
+    SetupCheckResponse,
+    SkillSummary,
     SkillsResponse,
     StatusResponse,
     SystemAllowlistsResponse,
+    SystemDoctorResponse,
     SystemGatewayPatchRequest,
     SystemGatewayPlatformsResponse,
     SystemGatewayResponse,
@@ -97,6 +103,7 @@ from app.services.hermes_adapter import (
 )
 from app.services.config_service import config_service
 from app.services.cron_service import cron_service
+from app.services.diagnostics_service import diagnostics_service
 from app.services.gateway_service import gateway_service
 from app.services.mcp_service import mcp_service
 from app.services.memory_service import memory_service
@@ -151,22 +158,22 @@ def get_health() -> HealthResponse:
 
 @app.get('/api/system/health', response_model=SystemHealthResponse, tags=['system'])
 def get_system_health() -> SystemHealthResponse:
-    return SystemHealthResponse(
-        status='ok',
-        service=settings.app_name,
-        api_version=settings.dashboard_api_version,
-        app_version=settings.app_version,
-        adapter=adapter_descriptor(),
-    )
+    return diagnostics_service.get_system_health()
+
+
+@app.get('/api/system/doctor', response_model=SystemDoctorResponse, tags=['system'])
+def get_system_doctor() -> SystemDoctorResponse:
+    return diagnostics_service.get_system_doctor()
 
 
 @app.get('/api/system/version', response_model=SystemVersionResponse, tags=['system'])
 def get_system_version() -> SystemVersionResponse:
-    return SystemVersionResponse(
-        service=settings.app_name,
-        api_version=settings.dashboard_api_version,
-        app_version=settings.app_version,
-    )
+    return diagnostics_service.get_system_version()
+
+
+@app.get('/api/system/setup/check', response_model=SetupCheckResponse, tags=['system'])
+def get_system_setup_check() -> SetupCheckResponse:
+    return diagnostics_service.get_setup_check()
 
 
 @app.get('/api/system/providers', response_model=ProviderCatalogResponse, tags=['system'])
@@ -597,6 +604,22 @@ def get_logs(
     lines: int = Query(100, ge=1, le=500),
 ) -> LogEntry:
     return LogEntry(**log_payload(profile=profile, log_name=log_name, lines=lines))
+
+
+@app.get('/api/agents/{agent_id}/diagnostics', response_model=AgentDiagnosticsResponse, tags=['system'])
+def get_agent_diagnostics(agent_id: str) -> AgentDiagnosticsResponse:
+    ensure_profile_exists(agent_id)
+    return diagnostics_service.get_agent_diagnostics(agent_id)
+
+
+@app.get('/api/agents/{agent_id}/logs', response_model=LogEntry, tags=['logs'])
+def get_agent_logs(
+    agent_id: str,
+    log_name: str = Query('agent'),
+    lines: int = Query(100, ge=1, le=500),
+) -> LogEntry:
+    ensure_profile_exists(agent_id)
+    return LogEntry(**diagnostics_service.get_agent_logs(agent_id, log_name=log_name, lines=lines))
 
 
 @app.get('/api/agents/{agent_id}/config', response_model=AgentConfigResponse, tags=['config'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -20,12 +20,51 @@ class AdapterDescriptor(BaseModel):
     hermes_bin_exists: bool
 
 
+class DiagnosticsRuntimeSummary(BaseModel):
+    active_profile: str | None = None
+    profile_count: int = 0
+    session_count: int = 0
+    cron_job_count: int = 0
+    gateway_state: str | None = None
+    status_excerpt: list[str] = Field(default_factory=list)
+
+
 class SystemHealthResponse(BaseModel):
     status: Literal["ok"]
     service: str
     api_version: str
     app_version: str
     adapter: AdapterDescriptor
+    runtime: DiagnosticsRuntimeSummary
+
+
+class DiagnosticsCheck(BaseModel):
+    name: str
+    ok: bool
+    detail: str
+    severity: Literal['info', 'warning', 'error'] = 'info'
+
+
+class SystemDoctorResponse(BaseModel):
+    status: Literal['ok', 'warning']
+    checks: list[DiagnosticsCheck] = Field(default_factory=list)
+
+
+class SetupCheckItem(BaseModel):
+    key: str
+    configured: bool
+    value: str
+
+
+class SetupCheckResponse(BaseModel):
+    status: Literal['ok', 'warning']
+    items: list[SetupCheckItem] = Field(default_factory=list)
+
+
+class AgentDiagnosticsResponse(BaseModel):
+    agent_id: str
+    status: Literal['ok', 'warning']
+    checks: list[DiagnosticsCheck] = Field(default_factory=list)
 
 
 class SystemVersionResponse(BaseModel):

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,3 +1,16 @@
-from . import config_service, cron_service, gateway_service, mcp_service, memory_service, provider_service, security_service, session_service, skill_service, tool_service, workspace_service
+from . import config_service, cron_service, diagnostics_service, gateway_service, mcp_service, memory_service, provider_service, security_service, session_service, skill_service, tool_service, workspace_service
 
-__all__ = ["config_service", "cron_service", "gateway_service", "mcp_service", "memory_service", "provider_service", "security_service", "session_service", "skill_service", "tool_service", "workspace_service"]
+__all__ = [
+    "config_service",
+    "cron_service",
+    "diagnostics_service",
+    "gateway_service",
+    "mcp_service",
+    "memory_service",
+    "provider_service",
+    "security_service",
+    "session_service",
+    "skill_service",
+    "tool_service",
+    "workspace_service",
+]

--- a/api/app/services/diagnostics_service.py
+++ b/api/app/services/diagnostics_service.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from app.core.settings import settings
+from app.models import (
+    AgentDiagnosticsResponse,
+    DiagnosticsCheck,
+    DiagnosticsRuntimeSummary,
+    SetupCheckItem,
+    SetupCheckResponse,
+    SystemDoctorResponse,
+    SystemHealthResponse,
+    SystemVersionResponse,
+)
+from app.services.hermes_adapter import ensure_profile_exists, log_payload, status_payload
+
+
+class DiagnosticsService:
+    def get_system_health(self) -> SystemHealthResponse:
+        status = status_payload()
+        return SystemHealthResponse(
+            status='ok',
+            service=settings.app_name,
+            api_version=settings.dashboard_api_version,
+            app_version=settings.app_version,
+            adapter=self.adapter_descriptor(),
+            runtime=self._runtime_summary(status),
+        )
+
+    def get_system_doctor(self) -> SystemDoctorResponse:
+        status = status_payload()
+        adapter = self.adapter_descriptor()
+        checks = [
+            DiagnosticsCheck(
+                name='hermes-binary',
+                ok=bool(adapter.get('hermes_bin_exists')),
+                detail=str(adapter.get('hermes_bin')),
+                severity='info' if bool(adapter.get('hermes_bin_exists')) else 'error',
+            ),
+            DiagnosticsCheck(
+                name='runtime-status',
+                ok=bool(status.get('ok', False)),
+                detail='; '.join(status.get('status_excerpt', []) or ['No runtime status available.']),
+                severity='info' if bool(status.get('ok', False)) else 'warning',
+            ),
+            DiagnosticsCheck(
+                name='gateway-state',
+                ok=bool(status.get('gateway_state') in {'running', 'configured', None}),
+                detail=str(status.get('gateway_state') or 'unknown'),
+                severity='info' if status.get('gateway_state') == 'running' else 'warning',
+            ),
+        ]
+        overall = 'ok' if all(check.ok for check in checks[:2]) else 'warning'
+        return SystemDoctorResponse(status=overall, checks=checks)
+
+    def get_system_version(self) -> SystemVersionResponse:
+        return SystemVersionResponse(
+            service=settings.app_name,
+            api_version=settings.dashboard_api_version,
+            app_version=settings.app_version,
+        )
+
+    def get_setup_check(self) -> SetupCheckResponse:
+        items = [
+            SetupCheckItem(key='hermes_home', configured=settings.hermes_home.exists(), value=str(settings.hermes_home)),
+            SetupCheckItem(key='hermes_bin', configured=settings.hermes_bin.exists(), value=str(settings.hermes_bin)),
+            SetupCheckItem(key='hermes_root', configured=settings.hermes_root.exists(), value=str(settings.hermes_root)),
+        ]
+        overall = 'ok' if all(item.configured for item in items) else 'warning'
+        return SetupCheckResponse(status=overall, items=items)
+
+    def get_agent_diagnostics(self, agent_id: str) -> AgentDiagnosticsResponse:
+        context = ensure_profile_exists(agent_id)
+        log_info = log_payload(profile=agent_id, log_name='agent', lines=20)
+        checks = [
+            DiagnosticsCheck(
+                name='profile-home',
+                ok=context.home.exists(),
+                detail=str(context.home),
+                severity='info' if context.home.exists() else 'error',
+            ),
+            DiagnosticsCheck(
+                name='agent-log',
+                ok=bool(log_info.get('path')),
+                detail=str(log_info.get('path')),
+                severity='info',
+            ),
+            DiagnosticsCheck(
+                name='runtime-status',
+                ok=bool(status_payload().get('ok', False)),
+                detail='Active runtime reachable.',
+                severity='info',
+            ),
+        ]
+        overall = 'ok' if all(check.ok for check in checks) else 'warning'
+        return AgentDiagnosticsResponse(agent_id=agent_id, status=overall, checks=checks)
+
+    def get_agent_logs(self, agent_id: str, log_name: str = 'agent', lines: int = 100) -> dict:
+        ensure_profile_exists(agent_id)
+        return log_payload(profile=agent_id, log_name=log_name, lines=lines)
+
+    def adapter_descriptor(self) -> dict[str, str | bool]:
+        return {
+            'kind': 'hermes-dashboard-api',
+            'hermes_home': str(settings.hermes_home),
+            'hermes_bin': str(settings.hermes_bin),
+            'hermes_bin_exists': settings.hermes_bin.exists(),
+        }
+
+    def _runtime_summary(self, status: dict) -> DiagnosticsRuntimeSummary:
+        return DiagnosticsRuntimeSummary(
+            active_profile=status.get('active_profile'),
+            profile_count=int(status.get('profile_count', 0) or 0),
+            session_count=int(status.get('session_count', 0) or 0),
+            cron_job_count=int(status.get('cron_job_count', 0) or 0),
+            gateway_state=status.get('gateway_state'),
+            status_excerpt=list(status.get('status_excerpt') or []),
+        )
+
+
+diagnostics_service = DiagnosticsService()

--- a/api/tests/test_dashboard_api_contracts.py
+++ b/api/tests/test_dashboard_api_contracts.py
@@ -14,18 +14,19 @@ def test_system_health_contract_is_available() -> None:
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload == {
-        'status': 'ok',
-        'service': settings.app_name,
-        'api_version': settings.dashboard_api_version,
-        'app_version': settings.app_version,
-        'adapter': {
-            'kind': 'hermes-dashboard-api',
-            'hermes_home': str(settings.hermes_home),
-            'hermes_bin': str(settings.hermes_bin),
-            'hermes_bin_exists': settings.hermes_bin.exists(),
-        },
+    assert payload['status'] == 'ok'
+    assert payload['service'] == settings.app_name
+    assert payload['api_version'] == settings.dashboard_api_version
+    assert payload['app_version'] == settings.app_version
+    assert payload['adapter'] == {
+        'kind': 'hermes-dashboard-api',
+        'hermes_home': str(settings.hermes_home),
+        'hermes_bin': str(settings.hermes_bin),
+        'hermes_bin_exists': settings.hermes_bin.exists(),
     }
+    assert payload['runtime']['active_profile'] == 'default'
+    assert 'profile_count' in payload['runtime']
+    assert 'gateway_state' in payload['runtime']
 
 
 def test_system_version_contract_is_available() -> None:

--- a/api/tests/test_diagnostics_api.py
+++ b/api/tests/test_diagnostics_api.py
@@ -1,0 +1,137 @@
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_system_diagnostics_contracts_expose_health_doctor_version_and_setup(monkeypatch) -> None:
+    from app.models import SetupCheckItem, SetupCheckResponse
+    from app.services import diagnostics_service as diagnostics_service_module
+
+    monkeypatch.setattr(
+        diagnostics_service_module.diagnostics_service,
+        'get_setup_check',
+        lambda: SetupCheckResponse(
+            status='ok',
+            items=[
+                SetupCheckItem(key='hermes_home', configured=True, value='/opt/data'),
+                SetupCheckItem(key='hermes_bin', configured=True, value='/opt/hermes/.venv/bin/hermes'),
+                SetupCheckItem(key='hermes_root', configured=True, value='/opt/hermes'),
+            ],
+        ),
+    )
+
+    monkeypatch.setattr(
+        diagnostics_service_module.diagnostics_service,
+        'adapter_descriptor',
+        lambda: {
+            'kind': 'hermes-dashboard-api',
+            'hermes_home': '/opt/data',
+            'hermes_bin': '/opt/hermes/.venv/bin/hermes',
+            'hermes_bin_exists': True,
+        },
+    )
+    monkeypatch.setattr(
+        diagnostics_service_module,
+        'status_payload',
+        lambda: {
+            'ok': True,
+            'active_profile': 'default',
+            'profile_count': 3,
+            'session_count': 7,
+            'cron_job_count': 2,
+            'gateway_state': 'running',
+            'status_excerpt': ['Hermes OK', 'Gateway running'],
+            'raw_status': 'Hermes OK\nGateway running',
+        },
+    )
+
+    health_response = client.get('/api/system/health')
+    assert health_response.status_code == 200
+    health = health_response.json()
+    assert health['status'] == 'ok'
+    assert health['service'] == 'Hermes Control Plane API'
+    assert health['adapter']['kind'] == 'hermes-dashboard-api'
+    assert health['runtime']['active_profile'] == 'default'
+    assert health['runtime']['gateway_state'] == 'running'
+
+    doctor_response = client.get('/api/system/doctor')
+    assert doctor_response.status_code == 200
+    doctor = doctor_response.json()
+    assert doctor['status'] == 'ok'
+    assert doctor['checks'][0]['name'] == 'hermes-binary'
+    assert doctor['checks'][0]['ok'] is True
+    assert any(check['name'] == 'runtime-status' for check in doctor['checks'])
+
+    version_response = client.get('/api/system/version')
+    assert version_response.status_code == 200
+    version = version_response.json()
+    assert version['api_version'] == 'v1alpha1'
+    assert version['app_version'] == '0.1.0'
+
+    setup_response = client.get('/api/system/setup/check')
+    assert setup_response.status_code == 200
+    setup = setup_response.json()
+    assert setup['status'] == 'ok'
+    assert setup['items'][0]['key'] == 'hermes_home'
+    assert setup['items'][0]['configured'] is True
+
+
+def test_agent_diagnostics_and_logs_contracts_are_profile_scoped(tmp_path, monkeypatch) -> None:
+    from app.services import diagnostics_service as diagnostics_service_module
+
+    log_dir = tmp_path / 'logs'
+    log_dir.mkdir(parents=True)
+    (log_dir / 'agent.log').write_text('INFO boot complete\nWARN retrying gateway\n', encoding='utf-8')
+
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+    monkeypatch.setattr(
+        diagnostics_service_module,
+        'ensure_profile_exists',
+        lambda profile='default': SimpleNamespace(home=tmp_path, profile=profile),
+    )
+    monkeypatch.setattr(
+        diagnostics_service_module,
+        'status_payload',
+        lambda: {
+            'ok': True,
+            'active_profile': 'default',
+            'profile_count': 2,
+            'session_count': 5,
+            'cron_job_count': 1,
+            'gateway_state': 'running',
+            'status_excerpt': ['Hermes OK'],
+            'raw_status': 'Hermes OK',
+        },
+    )
+    monkeypatch.setattr(
+        diagnostics_service_module,
+        'log_payload',
+        lambda profile='default', log_name='agent', lines=100: {
+            'log_name': log_name,
+            'path': str(log_dir / f'{log_name}.log'),
+            'lines': ['INFO boot complete', 'WARN retrying gateway'],
+            'total_lines_returned': 2,
+        },
+    )
+
+    diagnostics_response = client.get('/api/agents/default/diagnostics')
+    assert diagnostics_response.status_code == 200
+    diagnostics = diagnostics_response.json()
+    assert diagnostics['agent_id'] == 'default'
+    assert diagnostics['status'] == 'ok'
+    assert diagnostics['checks'][0]['name'] == 'profile-home'
+    assert diagnostics['checks'][0]['ok'] is True
+    assert any(check['name'] == 'agent-log' for check in diagnostics['checks'])
+
+    logs_response = client.get('/api/agents/default/logs')
+    assert logs_response.status_code == 200
+    logs = logs_response.json()
+    assert logs['log_name'] == 'agent'
+    assert logs['path'].endswith('/logs/agent.log')
+    assert logs['total_lines_returned'] == 2
+    assert logs['lines'][0] == 'INFO boot complete'

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -18,7 +18,9 @@ import {
   mockSessions,
   mockSkills,
   mockSystemAllowlists,
+  mockSystemDoctor,
   mockSystemGateway,
+  mockSystemHealth,
   mockSystemMemoryProfiles,
   mockSystemSecurity,
   mockSystemSkillLibrary,
@@ -27,15 +29,19 @@ import {
   mockWorkspaceArtifacts,
   mockWorkspaceFile,
   mockWorkspaceTree,
+  mockSetupCheck,
+  mockAgentDiagnostics,
 } from './mockData'
 import type {
   AgentConfigRecord,
+  AgentDiagnosticsRecord,
   AgentSecurityRecord,
   ApiResult,
   ApprovalRecord,
   CheckpointRecord,
   CreateProfilePayload,
   CronJob,
+  DiagnosticsCheckRecord,
   GatewayLifecycleRecord,
   GatewayPlatformRecord,
   LogEntry,
@@ -48,12 +54,15 @@ import type {
   ProviderCatalogRecord,
   ProviderRoutingRecord,
   RunRecord,
+  SetupCheckRecord,
   SessionDetailRecord,
   SessionRecord,
   Skill,
   SkillBroadcastPayload,
   SystemAllowlistsRecord,
+  SystemDoctorRecord,
   SystemGatewayRecord,
+  SystemHealthRecord,
   SystemMemoryProfileRecord,
   SystemSecurityRecord,
   SystemSkillLibraryRecord,
@@ -203,6 +212,57 @@ type BackendLogsResponse = {
   path: string
   lines: string[]
   total_lines_returned: number
+}
+
+type BackendSystemHealthResponse = {
+  status: 'ok'
+  service: string
+  api_version: string
+  app_version: string
+  adapter: {
+    kind: string
+    hermes_home: string
+    hermes_bin: string
+    hermes_bin_exists: boolean
+  }
+  runtime: {
+    active_profile?: string | null
+    profile_count: number
+    session_count: number
+    cron_job_count: number
+    gateway_state?: string | null
+    status_excerpt: string[]
+  }
+}
+
+type BackendDoctorResponse = {
+  status: 'ok' | 'warning'
+  checks: Array<{
+    name: string
+    ok: boolean
+    detail: string
+    severity: 'info' | 'warning' | 'error'
+  }>
+}
+
+type BackendSetupCheckResponse = {
+  status: 'ok' | 'warning'
+  items: Array<{
+    key: string
+    configured: boolean
+    value: string
+  }>
+}
+
+type BackendAgentDiagnosticsResponse = {
+  agent_id: string
+  status: 'ok' | 'warning'
+  checks: Array<{
+    name: string
+    ok: boolean
+    detail: string
+    severity: 'info' | 'warning' | 'error'
+  }>
 }
 
 type BackendRunsResponse = {
@@ -621,6 +681,57 @@ const normalizeLogs = (payload: BackendLogsResponse): LogEntry[] =>
     source: payload.log_name,
     message: line,
   }))
+
+const normalizeDiagnosticsChecks = (
+  checks: Array<{ name: string; ok: boolean; detail: string; severity: 'info' | 'warning' | 'error' }>,
+): DiagnosticsCheckRecord[] =>
+  checks.map((check) => ({
+    name: check.name,
+    ok: check.ok,
+    detail: check.detail,
+    severity: check.severity,
+  }))
+
+const normalizeSystemHealth = (payload: BackendSystemHealthResponse): SystemHealthRecord => ({
+  status: payload.status,
+  service: payload.service,
+  apiVersion: payload.api_version,
+  appVersion: payload.app_version,
+  adapter: {
+    kind: payload.adapter.kind,
+    hermesHome: payload.adapter.hermes_home,
+    hermesBin: payload.adapter.hermes_bin,
+    hermesBinExists: payload.adapter.hermes_bin_exists,
+  },
+  runtime: {
+    activeProfile: payload.runtime.active_profile ?? undefined,
+    profileCount: payload.runtime.profile_count,
+    sessionCount: payload.runtime.session_count,
+    cronJobCount: payload.runtime.cron_job_count,
+    gatewayState: payload.runtime.gateway_state ?? undefined,
+    statusExcerpt: payload.runtime.status_excerpt,
+  },
+})
+
+const normalizeDoctor = (payload: BackendDoctorResponse): SystemDoctorRecord => ({
+  status: payload.status,
+  checks: normalizeDiagnosticsChecks(payload.checks),
+})
+
+const normalizeSetupCheck = (payload: BackendSetupCheckResponse): SetupCheckRecord => ({
+  status: payload.status,
+  items: payload.items.map((item) => ({
+    key: item.key,
+    configured: item.configured,
+    value: item.value,
+  })),
+})
+
+const normalizeAgentDiagnostics = (payload: BackendAgentDiagnosticsResponse): AgentDiagnosticsRecord => ({
+  agentId: payload.agent_id,
+  status: payload.status,
+  checks: normalizeDiagnosticsChecks(payload.checks),
+})
 
 const compareRunsByStartedAtDesc = (left: RunRecord, right: RunRecord): number =>
   Date.parse(right.startedAt) - Date.parse(left.startedAt)
@@ -1094,9 +1205,33 @@ export const apiClient = {
     withFallback(async () => {
       const profilesPayload = await fetchJson<BackendProfilesResponse>('/profiles')
       const activeProfileId = profilesPayload.active_profile || profilesPayload.profiles[0]?.name || 'default'
-      const payload = await fetchJson<BackendLogsResponse>(`/logs?profile=${encodeURIComponent(activeProfileId)}`)
+      const payload = await fetchJson<BackendLogsResponse>(`/agents/${encodeURIComponent(activeProfileId)}/logs`)
       return normalizeLogs(payload)
     }, () => structuredClone(mockLogs)),
+
+  getSystemHealth: async (): Promise<ApiResult<SystemHealthRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendSystemHealthResponse>('/system/health')
+      return normalizeSystemHealth(payload)
+    }, () => structuredClone(mockSystemHealth)),
+
+  getSystemDoctor: async (): Promise<ApiResult<SystemDoctorRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendDoctorResponse>('/system/doctor')
+      return normalizeDoctor(payload)
+    }, () => structuredClone(mockSystemDoctor)),
+
+  getSystemSetupCheck: async (): Promise<ApiResult<SetupCheckRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendSetupCheckResponse>('/system/setup/check')
+      return normalizeSetupCheck(payload)
+    }, () => structuredClone(mockSetupCheck)),
+
+  getAgentDiagnostics: async (profileId: string): Promise<ApiResult<AgentDiagnosticsRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendAgentDiagnosticsResponse>(`/agents/${encodeURIComponent(profileId)}/diagnostics`)
+      return normalizeAgentDiagnostics(payload)
+    }, () => ({ ...structuredClone(mockAgentDiagnostics), agentId: profileId })),
 
   getConfigSummary: async (): Promise<ApiResult<BackendConfigSummary>> =>
     withFallback(async () => {

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -1,5 +1,6 @@
 import type {
   AgentConfigRecord,
+  AgentDiagnosticsRecord,
   AgentSecurityRecord,
   ApprovalRecord,
   CheckpointRecord,
@@ -19,6 +20,9 @@ import type {
   Skill,
   SystemAllowlistsRecord,
   SystemGatewayRecord,
+  SystemHealthRecord,
+  SystemDoctorRecord,
+  SetupCheckRecord,
   SystemMemoryProfileRecord,
   SystemSecurityRecord,
   SystemSkillLibraryRecord,
@@ -490,6 +494,55 @@ export const mockSystemGateway: SystemGatewayRecord = {
   writeRestrictions: [
     'Gateway secrets remain redacted in dashboard responses.',
     'Gateway v1 updates only the top-level gateway block and lifecycle state file.',
+  ],
+}
+
+export const mockSystemHealth: SystemHealthRecord = {
+  status: 'ok',
+  service: 'Hermes Control Plane API',
+  apiVersion: 'v1alpha1',
+  appVersion: '0.1.0',
+  adapter: {
+    kind: 'hermes-dashboard-api',
+    hermesHome: '/opt/data',
+    hermesBin: '/opt/hermes/.venv/bin/hermes',
+    hermesBinExists: true,
+  },
+  runtime: {
+    activeProfile: 'default',
+    profileCount: 5,
+    sessionCount: 12,
+    cronJobCount: 3,
+    gatewayState: 'running',
+    statusExcerpt: ['Hermes OK', 'Gateway running'],
+  },
+}
+
+export const mockSystemDoctor: SystemDoctorRecord = {
+  status: 'ok',
+  checks: [
+    { name: 'hermes-binary', ok: true, detail: '/opt/hermes/.venv/bin/hermes', severity: 'info' },
+    { name: 'runtime-status', ok: true, detail: 'Hermes OK; Gateway running', severity: 'info' },
+    { name: 'gateway-state', ok: true, detail: 'running', severity: 'info' },
+  ],
+}
+
+export const mockSetupCheck: SetupCheckRecord = {
+  status: 'ok',
+  items: [
+    { key: 'hermes_home', configured: true, value: '/opt/data' },
+    { key: 'hermes_bin', configured: true, value: '/opt/hermes/.venv/bin/hermes' },
+    { key: 'hermes_root', configured: true, value: '/opt/hermes' },
+  ],
+}
+
+export const mockAgentDiagnostics: AgentDiagnosticsRecord = {
+  agentId: 'default',
+  status: 'ok',
+  checks: [
+    { name: 'profile-home', ok: true, detail: '/opt/data/profiles/default', severity: 'info' },
+    { name: 'agent-log', ok: true, detail: '/opt/data/profiles/default/logs/agent.log', severity: 'info' },
+    { name: 'runtime-status', ok: true, detail: 'Active runtime reachable.', severity: 'info' },
   ],
 }
 

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,10 +1,11 @@
-import { Card, Col, Empty, Row, Segmented, Table, Tag, Typography } from 'antd'
+import { Card, Col, Empty, List, Row, Segmented, Space, Table, Tag, Typography } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { useMemo, useState } from 'react'
 import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
 import { PageHeader } from '../components/PageHeader'
-import type { LogEntry } from '../types'
+import { useProfileStore } from '../store/profileStore'
+import type { AgentDiagnosticsRecord, DiagnosticsCheckRecord, LogEntry, SetupCheckRecord, SystemDoctorRecord, SystemHealthRecord } from '../types'
 
 const columns: ColumnsType<LogEntry> = [
   { title: 'Timestamp', dataIndex: 'timestamp', render: (value) => new Date(value).toLocaleString() },
@@ -17,10 +18,24 @@ const columns: ColumnsType<LogEntry> = [
   },
 ]
 
+function checkColor(check: DiagnosticsCheckRecord): string {
+  if (!check.ok || check.severity === 'error') return 'red'
+  if (check.severity === 'warning') return 'gold'
+  return 'green'
+}
+
 export function LogsPage() {
   const [level, setLevel] = useState<'ALL' | LogEntry['level']>('ALL')
-  const { data, isLoading, isMock, error, refresh } = useApiQuery(apiClient.getLogs, [])
+  const { selectedProfileId } = useProfileStore()
+  const profileId = selectedProfileId ?? 'default'
 
+  const logsQuery = useApiQuery(apiClient.getLogs, [])
+  const healthQuery = useApiQuery<SystemHealthRecord>(apiClient.getSystemHealth, [])
+  const doctorQuery = useApiQuery<SystemDoctorRecord>(apiClient.getSystemDoctor, [])
+  const setupQuery = useApiQuery<SetupCheckRecord>(apiClient.getSystemSetupCheck, [])
+  const diagnosticsQuery = useApiQuery<AgentDiagnosticsRecord>(() => apiClient.getAgentDiagnostics(profileId), [profileId])
+
+  const data = logsQuery.data
   const filteredData = useMemo(
     () => (data ?? []).filter((entry) => level === 'ALL' || entry.level === level),
     [data, level],
@@ -28,17 +43,120 @@ export function LogsPage() {
   const infoCount = (data ?? []).filter((entry) => entry.level === 'INFO').length
   const warnCount = (data ?? []).filter((entry) => entry.level === 'WARN').length
   const errorCount = (data ?? []).filter((entry) => entry.level === 'ERROR').length
+  const isMock = logsQuery.isMock || healthQuery.isMock || doctorQuery.isMock || setupQuery.isMock || diagnosticsQuery.isMock
+  const error = logsQuery.error ?? healthQuery.error ?? doctorQuery.error ?? setupQuery.error ?? diagnosticsQuery.error
+
+  const refreshAll = async () => {
+    await logsQuery.refresh()
+    await healthQuery.refresh()
+    await doctorQuery.refresh()
+    await setupQuery.refresh()
+    await diagnosticsQuery.refresh()
+  }
 
   return (
     <div className="page-stack">
       <PageHeader
-        title="Logs"
-        description="Review control plane, sidecar, and automation logs with quick severity filtering."
+        title="Logs & Diagnostics"
+        description="Review control plane logs, system health, doctor checks, setup readiness, and profile-scoped diagnostics from one operational page."
         mock={isMock}
         error={error}
         actions={<Segmented value={level} options={['ALL', 'INFO', 'WARN', 'ERROR']} onChange={(value) => setLevel(value as typeof level)} />}
-        onRefresh={refresh}
+        onRefresh={refreshAll}
       />
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">System status</span>
+            <Typography.Title level={3}>{healthQuery.data?.status ?? 'unknown'}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Warnings</span>
+            <Typography.Title level={3}>{warnCount}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Errors</span>
+            <Typography.Title level={3}>{errorCount}</Typography.Title>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={8}>
+          <Card className="glass-panel qwen-section-card" title="System health" loading={healthQuery.isLoading}>
+            <Space direction="vertical" size={8}>
+              <Typography.Text strong>{healthQuery.data?.service}</Typography.Text>
+              <Typography.Text type="secondary">API {healthQuery.data?.apiVersion} · App {healthQuery.data?.appVersion}</Typography.Text>
+              <Typography.Text>Adapter: {healthQuery.data?.adapter.kind}</Typography.Text>
+              <Typography.Text>Hermes home: {healthQuery.data?.adapter.hermesHome}</Typography.Text>
+              <Typography.Text>Active profile: {healthQuery.data?.runtime.activeProfile ?? '—'}</Typography.Text>
+              <Typography.Text>Gateway: {healthQuery.data?.runtime.gatewayState ?? '—'}</Typography.Text>
+            </Space>
+          </Card>
+        </Col>
+        <Col xs={24} xl={8}>
+          <Card className="glass-panel qwen-section-card" title="Doctor checks" loading={doctorQuery.isLoading}>
+            <List
+              dataSource={doctorQuery.data?.checks ?? []}
+              renderItem={(check) => (
+                <List.Item>
+                  <Space direction="vertical" size={2}>
+                    <Space>
+                      <Typography.Text strong>{check.name}</Typography.Text>
+                      <Tag color={checkColor(check)}>{check.ok ? 'ok' : 'attention'}</Tag>
+                    </Space>
+                    <Typography.Text type="secondary">{check.detail}</Typography.Text>
+                  </Space>
+                </List.Item>
+              )}
+            />
+          </Card>
+        </Col>
+        <Col xs={24} xl={8}>
+          <Card className="glass-panel qwen-section-card" title="Setup readiness" loading={setupQuery.isLoading}>
+            <List
+              dataSource={setupQuery.data?.items ?? []}
+              renderItem={(item) => (
+                <List.Item>
+                  <Space direction="vertical" size={2}>
+                    <Space>
+                      <Typography.Text strong>{item.key}</Typography.Text>
+                      <Tag color={item.configured ? 'green' : 'red'}>{item.configured ? 'configured' : 'missing'}</Tag>
+                    </Space>
+                    <Typography.Text type="secondary">{item.value}</Typography.Text>
+                  </Space>
+                </List.Item>
+              )}
+            />
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24}>
+          <Card className="glass-panel qwen-section-card" title={`Agent diagnostics · ${profileId}`} loading={diagnosticsQuery.isLoading}>
+            <List
+              dataSource={diagnosticsQuery.data?.checks ?? []}
+              renderItem={(check) => (
+                <List.Item>
+                  <Space direction="vertical" size={2}>
+                    <Space>
+                      <Typography.Text strong>{check.name}</Typography.Text>
+                      <Tag color={checkColor(check)}>{check.severity}</Tag>
+                    </Space>
+                    <Typography.Text type="secondary">{check.detail}</Typography.Text>
+                  </Space>
+                </List.Item>
+              )}
+            />
+          </Card>
+        </Col>
+      </Row>
 
       <Row gutter={[16, 16]}>
         <Col xs={24} md={8}>
@@ -63,7 +181,7 @@ export function LogsPage() {
 
       <Card className="glass-panel qwen-section-card" title="Log stream">
         {filteredData.length ? (
-          <Table rowKey="id" loading={isLoading} dataSource={filteredData} columns={columns} pagination={false} />
+          <Table rowKey="id" loading={logsQuery.isLoading} dataSource={filteredData} columns={columns} pagination={false} />
         ) : (
           <Empty description="No logs for the selected level" />
         )}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -312,6 +312,58 @@ export interface LogEntry {
   message: string
 }
 
+export interface DiagnosticsRuntimeRecord {
+  activeProfile?: string
+  profileCount: number
+  sessionCount: number
+  cronJobCount: number
+  gatewayState?: string
+  statusExcerpt: string[]
+}
+
+export interface SystemHealthRecord {
+  status: 'ok'
+  service: string
+  apiVersion: string
+  appVersion: string
+  adapter: {
+    kind: string
+    hermesHome: string
+    hermesBin: string
+    hermesBinExists: boolean
+  }
+  runtime: DiagnosticsRuntimeRecord
+}
+
+export interface DiagnosticsCheckRecord {
+  name: string
+  ok: boolean
+  detail: string
+  severity: 'info' | 'warning' | 'error'
+}
+
+export interface SystemDoctorRecord {
+  status: 'ok' | 'warning'
+  checks: DiagnosticsCheckRecord[]
+}
+
+export interface SetupCheckItemRecord {
+  key: string
+  configured: boolean
+  value: string
+}
+
+export interface SetupCheckRecord {
+  status: 'ok' | 'warning'
+  items: SetupCheckItemRecord[]
+}
+
+export interface AgentDiagnosticsRecord {
+  agentId: string
+  status: 'ok' | 'warning'
+  checks: DiagnosticsCheckRecord[]
+}
+
 export interface ApiResult<T> {
   data: T
   mock: boolean


### PR DESCRIPTION
## Summary
- add stable diagnostics/system health contracts plus a dedicated diagnostics service
- expose system doctor/setup checks and profile-scoped diagnostics/log endpoints through the dashboard adapter boundary
- upgrade the Logs page into a combined Logs & Diagnostics operations surface

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_diagnostics_api.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build

Closes #16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system diagnostics endpoints including health status, system doctor checks, and setup validation.
  * Added agent-level diagnostics endpoint to retrieve profile-scoped diagnostic information.
  * Enhanced Logs page to display system health, diagnostic checks, setup readiness, and agent diagnostics in a unified view.
  * Added refresh capability for all diagnostics queries.

* **Tests**
  * Added comprehensive diagnostics API contract tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->