### PR TITLE
feat: add plugin slot registry contracts

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -78,6 +78,7 @@ from app.models import (
     SystemHealthResponse,
     SystemMcpServersResponse,
     SystemMemorySummaryResponse,
+    SystemPluginsResponse,
     SystemSecurityResponse,
     SystemSkillsLibraryResponse,
     SystemVersionResponse,
@@ -107,6 +108,7 @@ from app.services.diagnostics_service import diagnostics_service
 from app.services.gateway_service import gateway_service
 from app.services.mcp_service import mcp_service
 from app.services.memory_service import memory_service
+from app.services.plugin_service import plugin_service
 from app.services.provider_service import provider_service
 from app.services.run_service import run_service
 from app.services.runtime_registry import runtime_registry
@@ -174,6 +176,11 @@ def get_system_version() -> SystemVersionResponse:
 @app.get('/api/system/setup/check', response_model=SetupCheckResponse, tags=['system'])
 def get_system_setup_check() -> SetupCheckResponse:
     return diagnostics_service.get_setup_check()
+
+
+@app.get('/api/system/plugins', response_model=SystemPluginsResponse, tags=['system'])
+def get_system_plugins() -> SystemPluginsResponse:
+    return plugin_service.list_plugins()
 
 
 @app.get('/api/system/providers', response_model=ProviderCatalogResponse, tags=['system'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -73,6 +73,37 @@ class SystemVersionResponse(BaseModel):
     app_version: str
 
 
+class PluginSlotDescriptor(BaseModel):
+    kind: Literal['page_route', 'dashboard_widget', 'tool_result_renderer']
+    title: str
+    description: str
+
+
+class PluginExtension(BaseModel):
+    key: str
+    kind: Literal['page_route', 'dashboard_widget', 'tool_result_renderer']
+    title: str
+    description: str
+    target: str
+    path: str | None = None
+
+
+class DashboardPlugin(BaseModel):
+    id: str
+    name: str
+    version: str
+    enabled: bool = True
+    source: str
+    description: str
+    extensions: list[PluginExtension] = Field(default_factory=list)
+
+
+class SystemPluginsResponse(BaseModel):
+    supported_slots: list[PluginSlotDescriptor] = Field(default_factory=list)
+    plugins: list[DashboardPlugin] = Field(default_factory=list)
+    total_plugins: int = 0
+
+
 class AgentDefaults(BaseModel):
     model: str | None = None
     provider: str | None = None

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,4 +1,4 @@
-from . import config_service, cron_service, diagnostics_service, gateway_service, mcp_service, memory_service, provider_service, security_service, session_service, skill_service, tool_service, workspace_service
+from . import config_service, cron_service, diagnostics_service, gateway_service, mcp_service, memory_service, plugin_service, provider_service, security_service, session_service, skill_service, tool_service, workspace_service
 
 __all__ = [
     "config_service",
@@ -7,6 +7,7 @@ __all__ = [
     "gateway_service",
     "mcp_service",
     "memory_service",
+    "plugin_service",
     "provider_service",
     "security_service",
     "session_service",

--- a/api/app/services/plugin_service.py
+++ b/api/app/services/plugin_service.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from app.core.settings import settings
+from app.models import DashboardPlugin, PluginExtension, PluginSlotDescriptor, SystemPluginsResponse
+from app.utils import load_json_file
+
+_SUPPORTED_SLOTS = [
+    PluginSlotDescriptor(
+        kind='page_route',
+        title='Dashboard page routes',
+        description='Register dedicated dashboard pages surfaced through plugin-aware navigation and route shells.',
+    ),
+    PluginSlotDescriptor(
+        kind='dashboard_widget',
+        title='Dashboard cards & widgets',
+        description='Inject plugin-owned summary cards or widgets into explicit overview/dashboard surfaces.',
+    ),
+    PluginSlotDescriptor(
+        kind='tool_result_renderer',
+        title='Tool result renderers',
+        description='Attach plugin-provided result renderers for specific tool outputs without patching core pages.',
+    ),
+]
+
+
+class PluginService:
+    def list_plugins(self) -> SystemPluginsResponse:
+        manifest = load_json_file(self._manifest_path())
+        raw_plugins = manifest.get('plugins') if isinstance(manifest, dict) else []
+        plugins = [self._plugin_model(item) for item in raw_plugins if isinstance(item, dict)]
+        return SystemPluginsResponse(
+            supported_slots=list(_SUPPORTED_SLOTS),
+            plugins=plugins,
+            total_plugins=len(plugins),
+        )
+
+    def _manifest_path(self) -> Path:
+        return settings.hermes_home / 'dashboard_plugins.json'
+
+    def _plugin_model(self, payload: dict[str, Any]) -> DashboardPlugin:
+        extensions = payload.get('extensions') if isinstance(payload.get('extensions'), list) else []
+        return DashboardPlugin(
+            id=str(payload.get('id') or 'unknown-plugin'),
+            name=str(payload.get('name') or payload.get('id') or 'Unknown Plugin'),
+            version=str(payload.get('version') or '0.0.0'),
+            enabled=bool(payload.get('enabled', True)),
+            source=str(payload.get('source') or 'local'),
+            description=str(payload.get('description') or 'No description provided.'),
+            extensions=[self._extension_model(item) for item in extensions if isinstance(item, dict)],
+        )
+
+    def _extension_model(self, payload: dict[str, Any]) -> PluginExtension:
+        kind = str(payload.get('kind') or 'dashboard_widget')
+        if kind not in {'page_route', 'dashboard_widget', 'tool_result_renderer'}:
+            kind = 'dashboard_widget'
+        path = payload.get('path')
+        return PluginExtension(
+            key=str(payload.get('key') or payload.get('title') or kind),
+            kind=kind,
+            title=str(payload.get('title') or payload.get('key') or kind),
+            description=str(payload.get('description') or 'No description provided.'),
+            target=str(payload.get('target') or 'overview.sidebar'),
+            path=str(path) if path else None,
+        )
+
+
+plugin_service = PluginService()

--- a/api/tests/test_plugin_api.py
+++ b/api/tests/test_plugin_api.py
@@ -1,0 +1,81 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def write_json(path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding='utf-8')
+
+
+def test_system_plugins_contract_exposes_slot_catalog_and_registered_plugins(tmp_path, monkeypatch) -> None:
+    from app.services import plugin_service as plugin_service_module
+
+    write_json(
+        tmp_path / 'dashboard_plugins.json',
+        {
+            'plugins': [
+                {
+                    'id': 'ops-insights',
+                    'name': 'Ops Insights',
+                    'version': '0.1.0',
+                    'enabled': True,
+                    'source': 'local',
+                    'description': 'Adds operational extensions.',
+                    'extensions': [
+                        {
+                            'key': 'ops-route',
+                            'kind': 'page_route',
+                            'title': 'Ops Insights',
+                            'description': 'Plugin route for operations dashboards.',
+                            'target': 'settings.plugins',
+                            'path': '/plugins/ops-insights/ops-route',
+                        },
+                        {
+                            'key': 'queue-depth',
+                            'kind': 'dashboard_widget',
+                            'title': 'Queue Depth',
+                            'description': 'Shows queued work across agents.',
+                            'target': 'overview.sidebar',
+                        },
+                        {
+                            'key': 'tool-gallery',
+                            'kind': 'tool_result_renderer',
+                            'title': 'Tool Gallery',
+                            'description': 'Renders media-heavy tool outputs.',
+                            'target': 'tool:browser_get_images',
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+
+    monkeypatch.setattr(plugin_service_module.plugin_service, '_manifest_path', lambda: tmp_path / 'dashboard_plugins.json')
+
+    response = client.get('/api/system/plugins')
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload['total_plugins'] == 1
+    assert payload['supported_slots'][0]['kind'] == 'page_route'
+    assert payload['supported_slots'][1]['kind'] == 'dashboard_widget'
+    assert payload['supported_slots'][2]['kind'] == 'tool_result_renderer'
+    assert payload['plugins'][0]['id'] == 'ops-insights'
+    assert payload['plugins'][0]['extensions'][0]['path'] == '/plugins/ops-insights/ops-route'
+    assert payload['plugins'][0]['extensions'][1]['target'] == 'overview.sidebar'
+
+
+def test_system_plugins_contract_handles_missing_manifest() -> None:
+    response = client.get('/api/system/plugins')
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload['supported_slots']
+    assert payload['plugins'] == []
+    assert payload['total_plugins'] == 0

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,8 @@ import { LogsPage } from './pages/LogsPage'
 import { McpPage } from './pages/McpPage'
 import { MemoryPage } from './pages/MemoryPage'
 import { OverviewPage } from './pages/OverviewPage'
+import { PluginExtensionPage } from './pages/PluginExtensionPage'
+import { PluginsPage } from './pages/PluginsPage'
 import { ProfilesPage } from './pages/ProfilesPage'
 import { ProvidersPage } from './pages/ProvidersPage'
 import { SecurityPage } from './pages/SecurityPage'
@@ -24,6 +26,8 @@ function App() {
         <Route path="/overview" element={<OverviewPage />} />
         <Route path="/console" element={<ConsolePage />} />
         <Route path="/profiles" element={<ProfilesPage />} />
+        <Route path="/plugins" element={<PluginsPage />} />
+        <Route path="/plugins/:pluginId/:extensionKey" element={<PluginExtensionPage />} />
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/tools" element={<ToolsPage />} />
         <Route path="/mcp" element={<McpPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -22,6 +22,7 @@ import {
   mockSystemGateway,
   mockSystemHealth,
   mockSystemMemoryProfiles,
+  mockSystemPlugins,
   mockSystemSecurity,
   mockSystemSkillLibrary,
   mockToolsets,
@@ -41,6 +42,7 @@ import type {
   CheckpointRecord,
   CreateProfilePayload,
   CronJob,
+  DashboardPluginRecord,
   DiagnosticsCheckRecord,
   GatewayLifecycleRecord,
   GatewayPlatformRecord,
@@ -50,6 +52,8 @@ import type {
   MemoryProviderRecord,
   ModelCatalogRecord,
   OverviewResponse,
+  PluginExtensionRecord,
+  PluginSlotDescriptorRecord,
   Profile,
   ProviderCatalogRecord,
   ProviderRoutingRecord,
@@ -64,6 +68,7 @@ import type {
   SystemGatewayRecord,
   SystemHealthRecord,
   SystemMemoryProfileRecord,
+  SystemPluginsRecord,
   SystemSecurityRecord,
   SystemSkillLibraryRecord,
   ToggleSkillPayload,
@@ -263,6 +268,31 @@ type BackendAgentDiagnosticsResponse = {
     detail: string
     severity: 'info' | 'warning' | 'error'
   }>
+}
+
+type BackendSystemPluginsResponse = {
+  supported_slots: Array<{
+    kind: 'page_route' | 'dashboard_widget' | 'tool_result_renderer'
+    title: string
+    description: string
+  }>
+  plugins: Array<{
+    id: string
+    name: string
+    version: string
+    enabled: boolean
+    source: string
+    description: string
+    extensions: Array<{
+      key: string
+      kind: 'page_route' | 'dashboard_widget' | 'tool_result_renderer'
+      title: string
+      description: string
+      target: string
+      path?: string | null
+    }>
+  }>
+  total_plugins: number
 }
 
 type BackendRunsResponse = {
@@ -731,6 +761,31 @@ const normalizeAgentDiagnostics = (payload: BackendAgentDiagnosticsResponse): Ag
   agentId: payload.agent_id,
   status: payload.status,
   checks: normalizeDiagnosticsChecks(payload.checks),
+})
+
+const normalizeSystemPlugins = (payload: BackendSystemPluginsResponse): SystemPluginsRecord => ({
+  supportedSlots: payload.supported_slots.map((slot): PluginSlotDescriptorRecord => ({
+    kind: slot.kind,
+    title: slot.title,
+    description: slot.description,
+  })),
+  plugins: payload.plugins.map((plugin): DashboardPluginRecord => ({
+    id: plugin.id,
+    name: plugin.name,
+    version: plugin.version,
+    enabled: plugin.enabled,
+    source: plugin.source,
+    description: plugin.description,
+    extensions: plugin.extensions.map((extension): PluginExtensionRecord => ({
+      key: extension.key,
+      kind: extension.kind,
+      title: extension.title,
+      description: extension.description,
+      target: extension.target,
+      path: extension.path ?? undefined,
+    })),
+  })),
+  totalPlugins: payload.total_plugins,
 })
 
 const compareRunsByStartedAtDesc = (left: RunRecord, right: RunRecord): number =>
@@ -1226,6 +1281,12 @@ export const apiClient = {
       const payload = await fetchJson<BackendSetupCheckResponse>('/system/setup/check')
       return normalizeSetupCheck(payload)
     }, () => structuredClone(mockSetupCheck)),
+
+  getSystemPlugins: async (): Promise<ApiResult<SystemPluginsRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendSystemPluginsResponse>('/system/plugins')
+      return normalizeSystemPlugins(payload)
+    }, () => structuredClone(mockSystemPlugins)),
 
   getAgentDiagnostics: async (profileId: string): Promise<ApiResult<AgentDiagnosticsRecord>> =>
     withFallback(async () => {

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -5,6 +5,7 @@ import type {
   ApprovalRecord,
   CheckpointRecord,
   CronJob,
+  DashboardPluginRecord,
   GatewayPlatformRecord,
   LogEntry,
   McpServerRecord,
@@ -12,6 +13,7 @@ import type {
   MemoryProviderRecord,
   ModelCatalogRecord,
   OverviewResponse,
+  PluginSlotDescriptorRecord,
   Profile,
   ProviderCatalogRecord,
   ProviderRoutingRecord,
@@ -24,6 +26,7 @@ import type {
   SystemDoctorRecord,
   SetupCheckRecord,
   SystemMemoryProfileRecord,
+  SystemPluginsRecord,
   SystemSecurityRecord,
   SystemSkillLibraryRecord,
   ToolRecord,
@@ -544,6 +547,65 @@ export const mockAgentDiagnostics: AgentDiagnosticsRecord = {
     { name: 'agent-log', ok: true, detail: '/opt/data/profiles/default/logs/agent.log', severity: 'info' },
     { name: 'runtime-status', ok: true, detail: 'Active runtime reachable.', severity: 'info' },
   ],
+}
+
+export const mockPluginSlots: PluginSlotDescriptorRecord[] = [
+  {
+    kind: 'page_route',
+    title: 'Dashboard page routes',
+    description: 'Register dedicated dashboard pages surfaced through plugin-aware navigation and route shells.',
+  },
+  {
+    kind: 'dashboard_widget',
+    title: 'Dashboard cards & widgets',
+    description: 'Inject plugin-owned summary cards or widgets into explicit overview/dashboard surfaces.',
+  },
+  {
+    kind: 'tool_result_renderer',
+    title: 'Tool result renderers',
+    description: 'Attach plugin-provided result renderers for specific tool outputs without patching core pages.',
+  },
+]
+
+export const mockPlugins: DashboardPluginRecord[] = [
+  {
+    id: 'ops-insights',
+    name: 'Ops Insights',
+    version: '0.1.0',
+    enabled: true,
+    source: 'local',
+    description: 'Adds operational extensions for the Hermes dashboard.',
+    extensions: [
+      {
+        key: 'ops-route',
+        kind: 'page_route',
+        title: 'Ops Insights',
+        description: 'Plugin route for operational dashboards and drilldowns.',
+        target: 'settings.plugins',
+        path: '/plugins/ops-insights/ops-route',
+      },
+      {
+        key: 'queue-depth',
+        kind: 'dashboard_widget',
+        title: 'Queue Depth',
+        description: 'Shows queued work across agents.',
+        target: 'overview.sidebar',
+      },
+      {
+        key: 'tool-gallery',
+        kind: 'tool_result_renderer',
+        title: 'Tool Gallery',
+        description: 'Renders media-heavy tool outputs.',
+        target: 'tool:browser_get_images',
+      },
+    ],
+  },
+]
+
+export const mockSystemPlugins: SystemPluginsRecord = {
+  supportedSlots: mockPluginSlots,
+  plugins: mockPlugins,
+  totalPlugins: mockPlugins.length,
 }
 
 export const mockApprovals: ApprovalRecord[] = [

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -44,6 +44,7 @@ const navigationItems: MenuProps['items'] = [
     label: 'Settings',
     children: [
       { key: '/profiles', icon: <ProfileOutlined />, label: 'Profiles' },
+      { key: '/plugins', icon: <ApiOutlined />, label: 'Plugins' },
       { key: '/config', icon: <SettingOutlined />, label: 'Config' },
       { key: '/providers-models', icon: <SwapOutlined />, label: 'Providers & Models' },
       { key: '/skills', icon: <ToolOutlined />, label: 'Skills' },

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -3,13 +3,17 @@ import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
 import { PageHeader } from '../components/PageHeader'
 import { StatusBadge } from '../components/StatusBadge'
-import type { OverviewMetric } from '../types'
+import type { OverviewMetric, PluginExtensionRecord } from '../types'
 
 export function OverviewPage() {
   const { data, isLoading, isMock, error, refresh } = useApiQuery(apiClient.getOverview, [])
+  const pluginsQuery = useApiQuery(apiClient.getSystemPlugins, [])
   const metrics = data?.metrics ?? []
   const activity = data?.activity ?? []
   const alerts = data?.alerts ?? []
+  const pluginWidgets: PluginExtensionRecord[] = (pluginsQuery.data?.plugins ?? [])
+    .flatMap((plugin) => plugin.extensions)
+    .filter((extension) => extension.kind === 'dashboard_widget')
   const metricPlaceholders: OverviewMetric[] = Array.from({ length: 4 }, (_, index) => ({
     key: `placeholder-${index}`,
     label: '',
@@ -121,6 +125,26 @@ export function OverviewPage() {
                   ))
                 ) : (
                   <Typography.Text type="secondary">No alerts currently blocking rollout.</Typography.Text>
+                )}
+              </Space>
+            </Card>
+
+            <Card className="glass-panel qwen-section-card" title="Plugin widgets">
+              <Space direction="vertical" size={12} style={{ width: '100%' }}>
+                {pluginsQuery.isLoading ? (
+                  <Skeleton active paragraph={{ rows: 3 }} title={false} />
+                ) : pluginWidgets.length ? (
+                  pluginWidgets.map((widget) => (
+                    <Alert
+                      key={widget.key}
+                      type="info"
+                      showIcon
+                      message={widget.title}
+                      description={`${widget.description} · target: ${widget.target}`}
+                    />
+                  ))
+                ) : (
+                  <Typography.Text type="secondary">No dashboard widgets registered yet.</Typography.Text>
                 )}
               </Space>
             </Card>

--- a/web/src/pages/PluginExtensionPage.tsx
+++ b/web/src/pages/PluginExtensionPage.tsx
@@ -1,0 +1,73 @@
+import { Alert, Card, Empty, List, Space, Tag, Typography } from 'antd'
+import { useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import { useApiQuery } from '../api/hooks'
+import { PageHeader } from '../components/PageHeader'
+
+export function PluginExtensionPage() {
+  const { pluginId, extensionKey } = useParams<{ pluginId: string; extensionKey: string }>()
+  const pluginsQuery = useApiQuery(apiClient.getSystemPlugins, [])
+
+  const extension = useMemo(() => {
+    const plugin = (pluginsQuery.data?.plugins ?? []).find((item) => item.id === pluginId)
+    const selectedExtension = plugin?.extensions.find((item) => item.key === extensionKey)
+    return plugin && selectedExtension ? { plugin, extension: selectedExtension } : null
+  }, [extensionKey, pluginId, pluginsQuery.data])
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title={extension?.extension.title ?? 'Plugin extension'}
+        description="Generic route shell for plugin-owned dashboard pages in Plugin slots v1."
+        mock={pluginsQuery.isMock}
+        error={pluginsQuery.error}
+        onRefresh={pluginsQuery.refresh}
+      />
+
+      {!extension ? (
+        <Card className="glass-panel qwen-section-card">
+          <Empty description="Plugin extension not found" />
+        </Card>
+      ) : (
+        <Space direction="vertical" size={16} style={{ width: '100%' }}>
+          <Card className="glass-panel qwen-section-card" title="Extension metadata">
+            <Space direction="vertical" size={8}>
+              <Space wrap>
+                <Typography.Text strong>{extension.plugin.name}</Typography.Text>
+                <Tag>{extension.plugin.version}</Tag>
+                <Tag color={extension.plugin.enabled ? 'green' : 'default'}>{extension.plugin.enabled ? 'enabled' : 'disabled'}</Tag>
+                <Tag color="blue">{extension.extension.kind}</Tag>
+              </Space>
+              <Typography.Text type="secondary">{extension.extension.description}</Typography.Text>
+              <Typography.Text>Target slot: {extension.extension.target}</Typography.Text>
+              {extension.extension.path ? <Typography.Text>Route path: {extension.extension.path}</Typography.Text> : null}
+            </Space>
+          </Card>
+
+          <Alert
+            type="info"
+            showIcon
+            message="Plugin route shell active"
+            description="Plugin slots v1 provides an explicit, non-monkey-patched route shell. Rich plugin-owned rendering can evolve behind this stable contract in later phases."
+          />
+
+          <Card className="glass-panel qwen-section-card" title="Sibling extensions">
+            <List
+              dataSource={extension.plugin.extensions}
+              renderItem={(item) => (
+                <List.Item>
+                  <Space>
+                    <Typography.Text strong>{item.title}</Typography.Text>
+                    <Tag>{item.kind}</Tag>
+                    <Typography.Text type="secondary">{item.target}</Typography.Text>
+                  </Space>
+                </List.Item>
+              )}
+            />
+          </Card>
+        </Space>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -1,0 +1,103 @@
+import { Card, Col, List, Row, Space, Tag, Typography } from 'antd'
+import { Link } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import { useApiQuery } from '../api/hooks'
+import { PageHeader } from '../components/PageHeader'
+import type { DashboardPluginRecord } from '../types'
+
+function renderKindColor(kind: DashboardPluginRecord['extensions'][number]['kind']): string {
+  if (kind === 'page_route') return 'blue'
+  if (kind === 'dashboard_widget') return 'green'
+  return 'purple'
+}
+
+export function PluginsPage() {
+  const pluginsQuery = useApiQuery(apiClient.getSystemPlugins, [])
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="Plugin Slots"
+        description="Review explicit extension slots, registered plugins, and plugin-owned routes/widgets/renderers without patching core dashboard code."
+        mock={pluginsQuery.isMock}
+        error={pluginsQuery.error}
+        onRefresh={pluginsQuery.refresh}
+      />
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Supported slot types</span>
+            <Typography.Title level={3}>{pluginsQuery.data?.supportedSlots.length ?? 0}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Registered plugins</span>
+            <Typography.Title level={3}>{pluginsQuery.data?.totalPlugins ?? 0}</Typography.Title>
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card className="glass-panel qwen-summary-card">
+            <span className="qwen-summary-label">Enabled extensions</span>
+            <Typography.Title level={3}>
+              {(pluginsQuery.data?.plugins ?? []).flatMap((plugin) => plugin.extensions).length}
+            </Typography.Title>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={8}>
+          <Card className="glass-panel qwen-section-card" title="Supported slots" loading={pluginsQuery.isLoading}>
+            <List
+              dataSource={pluginsQuery.data?.supportedSlots ?? []}
+              renderItem={(slot) => (
+                <List.Item>
+                  <Space direction="vertical" size={2}>
+                    <Typography.Text strong>{slot.title}</Typography.Text>
+                    <Typography.Text code>{slot.kind}</Typography.Text>
+                    <Typography.Text type="secondary">{slot.description}</Typography.Text>
+                  </Space>
+                </List.Item>
+              )}
+            />
+          </Card>
+        </Col>
+        <Col xs={24} xl={16}>
+          <Card className="glass-panel qwen-section-card" title="Registered plugins" loading={pluginsQuery.isLoading}>
+            <List
+              dataSource={pluginsQuery.data?.plugins ?? []}
+              renderItem={(plugin) => (
+                <List.Item>
+                  <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                    <Space wrap>
+                      <Typography.Text strong>{plugin.name}</Typography.Text>
+                      <Tag color={plugin.enabled ? 'green' : 'default'}>{plugin.enabled ? 'enabled' : 'disabled'}</Tag>
+                      <Tag>{plugin.source}</Tag>
+                      <Tag>{plugin.version}</Tag>
+                    </Space>
+                    <Typography.Text type="secondary">{plugin.description}</Typography.Text>
+                    <Space wrap>
+                      {plugin.extensions.map((extension) =>
+                        extension.kind === 'page_route' && extension.path ? (
+                          <Link key={`${plugin.id}-${extension.key}`} to={extension.path}>
+                            <Tag color={renderKindColor(extension.kind)}>{extension.title}</Tag>
+                          </Link>
+                        ) : (
+                          <Tag key={`${plugin.id}-${extension.key}`} color={renderKindColor(extension.kind)}>
+                            {extension.title}
+                          </Tag>
+                        ),
+                      )}
+                    </Space>
+                  </Space>
+                </List.Item>
+              )}
+            />
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  )
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -364,6 +364,39 @@ export interface AgentDiagnosticsRecord {
   checks: DiagnosticsCheckRecord[]
 }
 
+export type PluginSlotKind = 'page_route' | 'dashboard_widget' | 'tool_result_renderer'
+
+export interface PluginSlotDescriptorRecord {
+  kind: PluginSlotKind
+  title: string
+  description: string
+}
+
+export interface PluginExtensionRecord {
+  key: string
+  kind: PluginSlotKind
+  title: string
+  description: string
+  target: string
+  path?: string
+}
+
+export interface DashboardPluginRecord {
+  id: string
+  name: string
+  version: string
+  enabled: boolean
+  source: string
+  description: string
+  extensions: PluginExtensionRecord[]
+}
+
+export interface SystemPluginsRecord {
+  supportedSlots: PluginSlotDescriptorRecord[]
+  plugins: DashboardPluginRecord[]
+  totalPlugins: number
+}
+
 export interface ApiResult<T> {
   data: T
   mock: boolean


### PR DESCRIPTION
## Summary
- add stable plugin slot registry contracts plus a dedicated plugin service
- expose explicit page-route, dashboard-widget, and tool-result-renderer slots through the dashboard adapter boundary
- add Plugins UI, generic plugin route shells, and overview widget rendering for plugin-owned dashboard surfaces

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_plugin_api.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build

Closes #17
