### PR TITLE
chore: harden frontend bundle and smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
       - run: npm ci
-      - run: npm run build
+      - run: npm run build:ci
       - run: npm run lint
 
   backend:

--- a/api/tests/test_ci_hardening.py
+++ b/api/tests/test_ci_hardening.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+ROOT = Path(__file__).resolve().parents[2]
+client = TestClient(app)
+
+
+def test_ci_workflow_enforces_frontend_bundle_check() -> None:
+    workflow_path = ROOT / '.github' / 'workflows' / 'ci.yml'
+    workflow = yaml.safe_load(workflow_path.read_text(encoding='utf-8'))
+
+    frontend_steps = workflow['jobs']['frontend']['steps']
+    run_steps = [step.get('run') for step in frontend_steps if isinstance(step, dict) and 'run' in step]
+
+    assert 'npm run build:ci' in run_steps
+
+
+def test_dashboard_api_smoke_contracts_cover_critical_system_surfaces() -> None:
+    critical_paths = [
+        '/api/health',
+        '/api/system/health',
+        '/api/system/providers',
+        '/api/system/gateway',
+        '/api/system/plugins',
+    ]
+
+    for path in critical_paths:
+        response = client.get(path)
+        assert response.status_code == 200, path

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:ci": "npm run build && node scripts/check-bundle.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/web/scripts/check-bundle.mjs
+++ b/web/scripts/check-bundle.mjs
@@ -1,0 +1,28 @@
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const assetsDir = join(process.cwd(), 'dist', 'assets')
+const jsFiles = readdirSync(assetsDir).filter((file) => file.endsWith('.js'))
+
+if (!jsFiles.length) {
+  console.error('No built JavaScript assets found in dist/assets.')
+  process.exit(1)
+}
+
+const chunks = jsFiles.map((file) => ({
+  file,
+  sizeBytes: statSync(join(assetsDir, file)).size,
+}))
+const maxAllowedBytes = 600 * 1024
+const oversize = chunks.filter((chunk) => chunk.sizeBytes > maxAllowedBytes)
+
+console.log(JSON.stringify({
+  maxAllowedBytes,
+  chunks,
+  oversize,
+}, null, 2))
+
+if (oversize.length) {
+  console.error(`Bundle policy failed: ${oversize.map((chunk) => chunk.file).join(', ')} exceed ${maxAllowedBytes} bytes.`)
+  process.exit(1)
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,47 +1,51 @@
+import { Suspense, lazy } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { DashboardLayout } from './layouts/DashboardLayout'
-import { ConfigPage } from './pages/ConfigPage'
-import { ConsolePage } from './pages/ConsolePage'
-import { CronJobsPage } from './pages/CronJobsPage'
-import { GatewayPage } from './pages/GatewayPage'
-import { LogsPage } from './pages/LogsPage'
-import { McpPage } from './pages/McpPage'
-import { MemoryPage } from './pages/MemoryPage'
-import { OverviewPage } from './pages/OverviewPage'
-import { PluginExtensionPage } from './pages/PluginExtensionPage'
-import { PluginsPage } from './pages/PluginsPage'
-import { ProfilesPage } from './pages/ProfilesPage'
-import { ProvidersPage } from './pages/ProvidersPage'
-import { SecurityPage } from './pages/SecurityPage'
-import { SessionsPage } from './pages/SessionsPage'
-import { SkillsPage } from './pages/SkillsPage'
-import { ToolsPage } from './pages/ToolsPage'
-import { WorkspacePage } from './pages/WorkspacePage'
+
+const ConfigPage = lazy(() => import('./pages/ConfigPage').then((module) => ({ default: module.ConfigPage })))
+const ConsolePage = lazy(() => import('./pages/ConsolePage').then((module) => ({ default: module.ConsolePage })))
+const CronJobsPage = lazy(() => import('./pages/CronJobsPage').then((module) => ({ default: module.CronJobsPage })))
+const GatewayPage = lazy(() => import('./pages/GatewayPage').then((module) => ({ default: module.GatewayPage })))
+const LogsPage = lazy(() => import('./pages/LogsPage').then((module) => ({ default: module.LogsPage })))
+const McpPage = lazy(() => import('./pages/McpPage').then((module) => ({ default: module.McpPage })))
+const MemoryPage = lazy(() => import('./pages/MemoryPage').then((module) => ({ default: module.MemoryPage })))
+const OverviewPage = lazy(() => import('./pages/OverviewPage').then((module) => ({ default: module.OverviewPage })))
+const PluginExtensionPage = lazy(() => import('./pages/PluginExtensionPage').then((module) => ({ default: module.PluginExtensionPage })))
+const PluginsPage = lazy(() => import('./pages/PluginsPage').then((module) => ({ default: module.PluginsPage })))
+const ProfilesPage = lazy(() => import('./pages/ProfilesPage').then((module) => ({ default: module.ProfilesPage })))
+const ProvidersPage = lazy(() => import('./pages/ProvidersPage').then((module) => ({ default: module.ProvidersPage })))
+const SecurityPage = lazy(() => import('./pages/SecurityPage').then((module) => ({ default: module.SecurityPage })))
+const SessionsPage = lazy(() => import('./pages/SessionsPage').then((module) => ({ default: module.SessionsPage })))
+const SkillsPage = lazy(() => import('./pages/SkillsPage').then((module) => ({ default: module.SkillsPage })))
+const ToolsPage = lazy(() => import('./pages/ToolsPage').then((module) => ({ default: module.ToolsPage })))
+const WorkspacePage = lazy(() => import('./pages/WorkspacePage').then((module) => ({ default: module.WorkspacePage })))
 
 function App() {
   return (
-    <Routes>
-      <Route element={<DashboardLayout />}>
-        <Route index element={<Navigate to="/overview" replace />} />
-        <Route path="/overview" element={<OverviewPage />} />
-        <Route path="/console" element={<ConsolePage />} />
-        <Route path="/profiles" element={<ProfilesPage />} />
-        <Route path="/plugins" element={<PluginsPage />} />
-        <Route path="/plugins/:pluginId/:extensionKey" element={<PluginExtensionPage />} />
-        <Route path="/skills" element={<SkillsPage />} />
-        <Route path="/tools" element={<ToolsPage />} />
-        <Route path="/mcp" element={<McpPage />} />
-        <Route path="/memory" element={<MemoryPage />} />
-        <Route path="/workspace" element={<WorkspacePage />} />
-        <Route path="/gateway" element={<GatewayPage />} />
-        <Route path="/security" element={<SecurityPage />} />
-        <Route path="/sessions" element={<SessionsPage />} />
-        <Route path="/config" element={<ConfigPage />} />
-        <Route path="/providers-models" element={<ProvidersPage />} />
-        <Route path="/cron-jobs" element={<CronJobsPage />} />
-        <Route path="/logs" element={<LogsPage />} />
-      </Route>
-    </Routes>
+    <Suspense fallback={<div className="page-stack">Loading dashboard…</div>}>
+      <Routes>
+        <Route element={<DashboardLayout />}>
+          <Route index element={<Navigate to="/overview" replace />} />
+          <Route path="/overview" element={<OverviewPage />} />
+          <Route path="/console" element={<ConsolePage />} />
+          <Route path="/profiles" element={<ProfilesPage />} />
+          <Route path="/plugins" element={<PluginsPage />} />
+          <Route path="/plugins/:pluginId/:extensionKey" element={<PluginExtensionPage />} />
+          <Route path="/skills" element={<SkillsPage />} />
+          <Route path="/tools" element={<ToolsPage />} />
+          <Route path="/mcp" element={<McpPage />} />
+          <Route path="/memory" element={<MemoryPage />} />
+          <Route path="/workspace" element={<WorkspacePage />} />
+          <Route path="/gateway" element={<GatewayPage />} />
+          <Route path="/security" element={<SecurityPage />} />
+          <Route path="/sessions" element={<SessionsPage />} />
+          <Route path="/config" element={<ConfigPage />} />
+          <Route path="/providers-models" element={<ProvidersPage />} />
+          <Route path="/cron-jobs" element={<CronJobsPage />} />
+          <Route path="/logs" element={<LogsPage />} />
+        </Route>
+      </Routes>
+    </Suspense>
   )
 }
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,55 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+function packageChunkName(id: string): string | undefined {
+  const marker = '/node_modules/'
+  const markerIndex = id.lastIndexOf(marker)
+  if (markerIndex === -1) {
+    return undefined
+  }
+
+  const packagePath = id.slice(markerIndex + marker.length)
+  const segments = packagePath.split('/')
+  const packageName = segments[0]?.startsWith('@') ? `${segments[0]}/${segments[1]}` : segments[0]
+
+  if (!packageName) {
+    return undefined
+  }
+
+  if (packageName === 'react' || packageName === 'react-dom' || packageName === 'react-router-dom' || packageName === 'scheduler') {
+    return 'react-vendor'
+  }
+
+  if (packageName === 'antd') {
+    const antdSegment = segments[2]
+    return antdSegment ? `antd-${antdSegment}` : 'antd-core'
+  }
+
+  if (packageName === '@ant-design/icons') {
+    return 'antd-icons'
+  }
+
+  if (packageName.startsWith('rc-')) {
+    return `rc-${packageName.slice(3)}`
+  }
+
+  if (packageName === 'zustand') {
+    return 'state-vendor'
+  }
+
+  return 'vendor'
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          return packageChunkName(id)
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add backend smoke coverage for critical dashboard API surfaces and enforce it in CI
- add frontend CI bundle policy with explicit artifact-size enforcement
- split the dashboard app and vendor bundles to reduce oversized chunk risk in production

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_ci_hardening.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build:ci

Closes #36


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added CI workflow validation test suite
  * Added smoke contract tests for critical dashboard endpoints

* **Chores**
  * CI build process now enforces bundle size limits
  * Configured optimized code splitting to improve app load performance and reduce initial bundle size

<!-- end of auto-generated comment: release notes by coderabbit.ai -->