### PR TITLE
test: add dashboard route smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - run: npm ci
       - run: npm run build:ci
+      - run: npm run smoke:routes
       - run: npm run lint
 
   backend:

--- a/api/tests/test_ui_smoke_hardening.py
+++ b/api/tests/test_ui_smoke_hardening.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+CRITICAL_ROUTE_KEYS = [
+    'overview',
+    'console',
+    'sessions',
+    'tools',
+    'mcp',
+    'memory',
+    'workspace',
+    'gateway',
+    'security',
+    'cron-jobs',
+    'logs',
+    'profiles',
+    'plugins',
+    'config',
+    'providers-models',
+    'skills',
+]
+
+
+def test_ci_workflow_runs_ui_route_smoke_check() -> None:
+    workflow_path = ROOT / '.github' / 'workflows' / 'ci.yml'
+    workflow = yaml.safe_load(workflow_path.read_text(encoding='utf-8'))
+
+    frontend_steps = workflow['jobs']['frontend']['steps']
+    run_steps = [step.get('run') for step in frontend_steps if isinstance(step, dict) and 'run' in step]
+
+    assert 'npm run smoke:routes' in run_steps
+
+
+def test_route_manifest_covers_critical_dashboard_pages() -> None:
+    manifest_path = ROOT / 'web' / 'route-manifest.json'
+    assert manifest_path.exists(), 'route-manifest.json should define critical dashboard routes'
+
+    manifest = yaml.safe_load(manifest_path.read_text(encoding='utf-8'))
+    route_keys = [route['key'] for route in manifest['routes']]
+
+    assert route_keys == CRITICAL_ROUTE_KEYS

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "build:ci": "npm run build && node scripts/check-bundle.mjs",
+    "smoke:routes": "node scripts/check-routes.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/web/route-manifest.json
+++ b/web/route-manifest.json
@@ -1,0 +1,100 @@
+{
+  "routes": [
+    {
+      "key": "overview",
+      "path": "/overview",
+      "label": "Overview",
+      "group": "control-group"
+    },
+    {
+      "key": "console",
+      "path": "/console",
+      "label": "Console",
+      "group": "control-group"
+    },
+    {
+      "key": "sessions",
+      "path": "/sessions",
+      "label": "Sessions",
+      "group": "control-group"
+    },
+    {
+      "key": "tools",
+      "path": "/tools",
+      "label": "Tools",
+      "group": "control-group"
+    },
+    {
+      "key": "mcp",
+      "path": "/mcp",
+      "label": "MCP",
+      "group": "control-group"
+    },
+    {
+      "key": "memory",
+      "path": "/memory",
+      "label": "Memory",
+      "group": "control-group"
+    },
+    {
+      "key": "workspace",
+      "path": "/workspace",
+      "label": "Workspace",
+      "group": "control-group"
+    },
+    {
+      "key": "gateway",
+      "path": "/gateway",
+      "label": "Gateway",
+      "group": "control-group"
+    },
+    {
+      "key": "security",
+      "path": "/security",
+      "label": "Security",
+      "group": "control-group"
+    },
+    {
+      "key": "cron-jobs",
+      "path": "/cron-jobs",
+      "label": "Cron Jobs",
+      "group": "control-group"
+    },
+    {
+      "key": "logs",
+      "path": "/logs",
+      "label": "Logs",
+      "group": "control-group"
+    },
+    {
+      "key": "profiles",
+      "path": "/profiles",
+      "label": "Profiles",
+      "group": "settings-group"
+    },
+    {
+      "key": "plugins",
+      "path": "/plugins",
+      "label": "Plugins",
+      "group": "settings-group"
+    },
+    {
+      "key": "config",
+      "path": "/config",
+      "label": "Config",
+      "group": "settings-group"
+    },
+    {
+      "key": "providers-models",
+      "path": "/providers-models",
+      "label": "Providers & Models",
+      "group": "settings-group"
+    },
+    {
+      "key": "skills",
+      "path": "/skills",
+      "label": "Skills",
+      "group": "settings-group"
+    }
+  ]
+}

--- a/web/scripts/check-routes.mjs
+++ b/web/scripts/check-routes.mjs
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const manifest = JSON.parse(readFileSync(join(root, 'route-manifest.json'), 'utf8'))
+const appSource = readFileSync(join(root, 'src', 'App.tsx'), 'utf8')
+const layoutSource = readFileSync(join(root, 'src', 'layouts', 'DashboardLayout.tsx'), 'utf8')
+
+const problems = []
+
+for (const route of manifest.routes) {
+  const appToken = `path=\"${route.path}\"`
+  if (!appSource.includes(appToken)) {
+    problems.push(`App.tsx missing route path ${route.path}`)
+  }
+
+  const menuKeyToken = `key: '${route.path}'`
+  if (!layoutSource.includes(menuKeyToken)) {
+    problems.push(`DashboardLayout.tsx missing menu key ${route.path}`)
+  }
+
+  const menuLabelToken = `label: '${route.label}'`
+  if (!layoutSource.includes(menuLabelToken)) {
+    problems.push(`DashboardLayout.tsx missing menu label ${route.label}`)
+  }
+
+  const menuGroupToken = `key: '${route.group}'`
+  if (!layoutSource.includes(menuGroupToken)) {
+    problems.push(`DashboardLayout.tsx missing menu group ${route.group}`)
+  }
+}
+
+const summary = {
+  routeCount: manifest.routes.length,
+  checkedPaths: manifest.routes.map((route) => route.path),
+  problems,
+}
+
+console.log(JSON.stringify(summary, null, 2))
+
+if (problems.length) {
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- add a lightweight dashboard route manifest for critical UI pages
- add a CI-friendly route smoke script that checks App route paths and sidebar menu coverage against the manifest
- enforce the new route smoke check in frontend CI

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_ui_smoke_hardening.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build:ci
- npm run smoke:routes

Closes #38
