### PR TITLE
refactor: centralize dashboard route metadata

### DIFF
--- a/api/tests/test_route_manifest_integration.py
+++ b/api/tests/test_route_manifest_integration.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_frontend_route_registry_consumes_manifest_as_single_source_of_truth() -> None:
+    route_registry = ROOT / 'web' / 'src' / 'routeRegistry.tsx'
+    app_source = (ROOT / 'web' / 'src' / 'App.tsx').read_text(encoding='utf-8')
+    layout_source = (ROOT / 'web' / 'src' / 'layouts' / 'DashboardLayout.tsx').read_text(encoding='utf-8')
+
+    assert route_registry.exists(), 'routeRegistry.tsx should centralize manifest-backed route metadata'
+
+    registry_source = route_registry.read_text(encoding='utf-8')
+    assert "from '../route-manifest.json'" in registry_source or 'from "../route-manifest.json"' in registry_source
+    assert 'dashboardRoutes' in registry_source
+    assert 'navigationItems' in registry_source
+    assert 'dashboardRoutes' in app_source
+    assert 'navigationItems' in layout_source
+    assert "path=\"/overview\"" not in app_source
+    assert "key: '/overview'" not in layout_source

--- a/web/scripts/check-routes.mjs
+++ b/web/scripts/check-routes.mjs
@@ -5,29 +5,20 @@ const root = process.cwd()
 const manifest = JSON.parse(readFileSync(join(root, 'route-manifest.json'), 'utf8'))
 const appSource = readFileSync(join(root, 'src', 'App.tsx'), 'utf8')
 const layoutSource = readFileSync(join(root, 'src', 'layouts', 'DashboardLayout.tsx'), 'utf8')
+const registrySource = readFileSync(join(root, 'src', 'routeRegistry.tsx'), 'utf8')
 
 const problems = []
 
-for (const route of manifest.routes) {
-  const appToken = `path=\"${route.path}\"`
-  if (!appSource.includes(appToken)) {
-    problems.push(`App.tsx missing route path ${route.path}`)
-  }
+if (!registrySource.includes("from '../route-manifest.json'") && !registrySource.includes('from "../route-manifest.json"')) {
+  problems.push('routeRegistry.tsx missing route-manifest.json import')
+}
 
-  const menuKeyToken = `key: '${route.path}'`
-  if (!layoutSource.includes(menuKeyToken)) {
-    problems.push(`DashboardLayout.tsx missing menu key ${route.path}`)
-  }
+if (!appSource.includes('dashboardRoutes')) {
+  problems.push('App.tsx missing dashboardRoutes registry usage')
+}
 
-  const menuLabelToken = `label: '${route.label}'`
-  if (!layoutSource.includes(menuLabelToken)) {
-    problems.push(`DashboardLayout.tsx missing menu label ${route.label}`)
-  }
-
-  const menuGroupToken = `key: '${route.group}'`
-  if (!layoutSource.includes(menuGroupToken)) {
-    problems.push(`DashboardLayout.tsx missing menu group ${route.group}`)
-  }
+if (!layoutSource.includes('navigationItems')) {
+  problems.push('DashboardLayout.tsx missing navigationItems registry usage')
 }
 
 const summary = {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,24 +1,9 @@
 import { Suspense, lazy } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { DashboardLayout } from './layouts/DashboardLayout'
+import { dashboardRoutes } from './routeRegistry'
 
-const ConfigPage = lazy(() => import('./pages/ConfigPage').then((module) => ({ default: module.ConfigPage })))
-const ConsolePage = lazy(() => import('./pages/ConsolePage').then((module) => ({ default: module.ConsolePage })))
-const CronJobsPage = lazy(() => import('./pages/CronJobsPage').then((module) => ({ default: module.CronJobsPage })))
-const GatewayPage = lazy(() => import('./pages/GatewayPage').then((module) => ({ default: module.GatewayPage })))
-const LogsPage = lazy(() => import('./pages/LogsPage').then((module) => ({ default: module.LogsPage })))
-const McpPage = lazy(() => import('./pages/McpPage').then((module) => ({ default: module.McpPage })))
-const MemoryPage = lazy(() => import('./pages/MemoryPage').then((module) => ({ default: module.MemoryPage })))
-const OverviewPage = lazy(() => import('./pages/OverviewPage').then((module) => ({ default: module.OverviewPage })))
 const PluginExtensionPage = lazy(() => import('./pages/PluginExtensionPage').then((module) => ({ default: module.PluginExtensionPage })))
-const PluginsPage = lazy(() => import('./pages/PluginsPage').then((module) => ({ default: module.PluginsPage })))
-const ProfilesPage = lazy(() => import('./pages/ProfilesPage').then((module) => ({ default: module.ProfilesPage })))
-const ProvidersPage = lazy(() => import('./pages/ProvidersPage').then((module) => ({ default: module.ProvidersPage })))
-const SecurityPage = lazy(() => import('./pages/SecurityPage').then((module) => ({ default: module.SecurityPage })))
-const SessionsPage = lazy(() => import('./pages/SessionsPage').then((module) => ({ default: module.SessionsPage })))
-const SkillsPage = lazy(() => import('./pages/SkillsPage').then((module) => ({ default: module.SkillsPage })))
-const ToolsPage = lazy(() => import('./pages/ToolsPage').then((module) => ({ default: module.ToolsPage })))
-const WorkspacePage = lazy(() => import('./pages/WorkspacePage').then((module) => ({ default: module.WorkspacePage })))
 
 function App() {
   return (
@@ -26,23 +11,11 @@ function App() {
       <Routes>
         <Route element={<DashboardLayout />}>
           <Route index element={<Navigate to="/overview" replace />} />
-          <Route path="/overview" element={<OverviewPage />} />
-          <Route path="/console" element={<ConsolePage />} />
-          <Route path="/profiles" element={<ProfilesPage />} />
-          <Route path="/plugins" element={<PluginsPage />} />
+          {dashboardRoutes.map((route) => {
+            const Component = route.component
+            return <Route key={route.key} path={route.path} element={<Component />} />
+          })}
           <Route path="/plugins/:pluginId/:extensionKey" element={<PluginExtensionPage />} />
-          <Route path="/skills" element={<SkillsPage />} />
-          <Route path="/tools" element={<ToolsPage />} />
-          <Route path="/mcp" element={<McpPage />} />
-          <Route path="/memory" element={<MemoryPage />} />
-          <Route path="/workspace" element={<WorkspacePage />} />
-          <Route path="/gateway" element={<GatewayPage />} />
-          <Route path="/security" element={<SecurityPage />} />
-          <Route path="/sessions" element={<SessionsPage />} />
-          <Route path="/config" element={<ConfigPage />} />
-          <Route path="/providers-models" element={<ProvidersPage />} />
-          <Route path="/cron-jobs" element={<CronJobsPage />} />
-          <Route path="/logs" element={<LogsPage />} />
         </Route>
       </Routes>
     </Suspense>

--- a/web/src/layouts/DashboardLayout.tsx
+++ b/web/src/layouts/DashboardLayout.tsx
@@ -1,56 +1,10 @@
-import {
-  ApiOutlined,
-  ClockCircleOutlined,
-  ConsoleSqlOutlined,
-  DatabaseOutlined,
-  FileTextOutlined,
-  FolderOpenOutlined,
-  MessageOutlined,
-  ProfileOutlined,
-  RadarChartOutlined,
-  SafetyCertificateOutlined,
-  SettingOutlined,
-  SwapOutlined,
-  ToolOutlined,
-} from '@ant-design/icons'
 import { Layout, Menu, Select, Space, Tag, Typography } from 'antd'
-import type { MenuProps } from 'antd'
 import { useEffect } from 'react'
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
+import { navigationItems } from '../routeRegistry'
 import { useProfileStore } from '../store/profileStore'
-
-const navigationItems: MenuProps['items'] = [
-  {
-    key: 'control-group',
-    label: 'Control',
-    children: [
-      { key: '/overview', label: 'Overview' },
-      { key: '/console', icon: <ConsoleSqlOutlined />, label: 'Console' },
-      { key: '/sessions', icon: <RadarChartOutlined />, label: 'Sessions' },
-      { key: '/tools', icon: <ToolOutlined />, label: 'Tools' },
-      { key: '/mcp', icon: <ApiOutlined />, label: 'MCP' },
-      { key: '/memory', icon: <DatabaseOutlined />, label: 'Memory' },
-      { key: '/workspace', icon: <FolderOpenOutlined />, label: 'Workspace' },
-      { key: '/gateway', icon: <MessageOutlined />, label: 'Gateway' },
-      { key: '/security', icon: <SafetyCertificateOutlined />, label: 'Security' },
-      { key: '/cron-jobs', icon: <ClockCircleOutlined />, label: 'Cron Jobs' },
-      { key: '/logs', icon: <FileTextOutlined />, label: 'Logs' },
-    ],
-  },
-  {
-    key: 'settings-group',
-    label: 'Settings',
-    children: [
-      { key: '/profiles', icon: <ProfileOutlined />, label: 'Profiles' },
-      { key: '/plugins', icon: <ApiOutlined />, label: 'Plugins' },
-      { key: '/config', icon: <SettingOutlined />, label: 'Config' },
-      { key: '/providers-models', icon: <SwapOutlined />, label: 'Providers & Models' },
-      { key: '/skills', icon: <ToolOutlined />, label: 'Skills' },
-    ],
-  },
-]
 
 export function DashboardLayout() {
   const navigate = useNavigate()

--- a/web/src/routeRegistry.tsx
+++ b/web/src/routeRegistry.tsx
@@ -1,0 +1,114 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  ApiOutlined,
+  ClockCircleOutlined,
+  ConsoleSqlOutlined,
+  DatabaseOutlined,
+  FileTextOutlined,
+  FolderOpenOutlined,
+  MessageOutlined,
+  ProfileOutlined,
+  RadarChartOutlined,
+  SafetyCertificateOutlined,
+  SettingOutlined,
+  SwapOutlined,
+  ToolOutlined,
+} from '@ant-design/icons'
+import type { MenuProps } from 'antd'
+import type { ComponentType, LazyExoticComponent, ReactNode } from 'react'
+import { lazy } from 'react'
+import routeManifest from '../route-manifest.json'
+
+const ConfigPage = lazy(() => import('./pages/ConfigPage').then((module) => ({ default: module.ConfigPage })))
+const ConsolePage = lazy(() => import('./pages/ConsolePage').then((module) => ({ default: module.ConsolePage })))
+const CronJobsPage = lazy(() => import('./pages/CronJobsPage').then((module) => ({ default: module.CronJobsPage })))
+const GatewayPage = lazy(() => import('./pages/GatewayPage').then((module) => ({ default: module.GatewayPage })))
+const LogsPage = lazy(() => import('./pages/LogsPage').then((module) => ({ default: module.LogsPage })))
+const McpPage = lazy(() => import('./pages/McpPage').then((module) => ({ default: module.McpPage })))
+const MemoryPage = lazy(() => import('./pages/MemoryPage').then((module) => ({ default: module.MemoryPage })))
+const OverviewPage = lazy(() => import('./pages/OverviewPage').then((module) => ({ default: module.OverviewPage })))
+const PluginsPage = lazy(() => import('./pages/PluginsPage').then((module) => ({ default: module.PluginsPage })))
+const ProfilesPage = lazy(() => import('./pages/ProfilesPage').then((module) => ({ default: module.ProfilesPage })))
+const ProvidersPage = lazy(() => import('./pages/ProvidersPage').then((module) => ({ default: module.ProvidersPage })))
+const SecurityPage = lazy(() => import('./pages/SecurityPage').then((module) => ({ default: module.SecurityPage })))
+const SessionsPage = lazy(() => import('./pages/SessionsPage').then((module) => ({ default: module.SessionsPage })))
+const SkillsPage = lazy(() => import('./pages/SkillsPage').then((module) => ({ default: module.SkillsPage })))
+const ToolsPage = lazy(() => import('./pages/ToolsPage').then((module) => ({ default: module.ToolsPage })))
+const WorkspacePage = lazy(() => import('./pages/WorkspacePage').then((module) => ({ default: module.WorkspacePage })))
+
+type RouteGroup = 'control-group' | 'settings-group'
+
+type ManifestRoute = {
+  key: string
+  path: string
+  label: string
+  group: RouteGroup
+}
+
+type DashboardRoute = ManifestRoute & {
+  icon?: ReactNode
+  component: LazyExoticComponent<ComponentType>
+}
+
+const componentByKey: Record<string, LazyExoticComponent<ComponentType>> = {
+  overview: OverviewPage,
+  console: ConsolePage,
+  sessions: SessionsPage,
+  tools: ToolsPage,
+  mcp: McpPage,
+  memory: MemoryPage,
+  workspace: WorkspacePage,
+  gateway: GatewayPage,
+  security: SecurityPage,
+  'cron-jobs': CronJobsPage,
+  logs: LogsPage,
+  profiles: ProfilesPage,
+  plugins: PluginsPage,
+  config: ConfigPage,
+  'providers-models': ProvidersPage,
+  skills: SkillsPage,
+}
+
+const iconByKey: Record<string, ReactNode | undefined> = {
+  overview: undefined,
+  console: <ConsoleSqlOutlined />,
+  sessions: <RadarChartOutlined />,
+  tools: <ToolOutlined />,
+  mcp: <ApiOutlined />,
+  memory: <DatabaseOutlined />,
+  workspace: <FolderOpenOutlined />,
+  gateway: <MessageOutlined />,
+  security: <SafetyCertificateOutlined />,
+  'cron-jobs': <ClockCircleOutlined />,
+  logs: <FileTextOutlined />,
+  profiles: <ProfileOutlined />,
+  plugins: <ApiOutlined />,
+  config: <SettingOutlined />,
+  'providers-models': <SwapOutlined />,
+  skills: <ToolOutlined />,
+}
+
+const groupLabels: Record<RouteGroup, string> = {
+  'control-group': 'Control',
+  'settings-group': 'Settings',
+}
+
+const manifestRoutes = routeManifest.routes as ManifestRoute[]
+
+export const dashboardRoutes: DashboardRoute[] = manifestRoutes.map((route) => ({
+  ...route,
+  icon: iconByKey[route.key],
+  component: componentByKey[route.key],
+}))
+
+export const navigationItems: MenuProps['items'] = (Object.keys(groupLabels) as RouteGroup[]).map((group) => ({
+  key: group,
+  label: groupLabels[group],
+  children: dashboardRoutes
+    .filter((route) => route.group === group)
+    .map((route) => ({
+      key: route.path,
+      icon: route.icon,
+      label: route.label,
+    })),
+}))

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -9,6 +9,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- add a manifest-backed frontend route registry as the single source of truth for dashboard routes and navigation
- refactor App and DashboardLayout to consume shared route metadata instead of duplicating critical paths and labels
- keep the existing route smoke checks while aligning them to the new registry pattern

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests/test_route_manifest_integration.py -q
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run build:ci
- npm run smoke:routes

Closes #40


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added integration test validating that route metadata is properly sourced from the centralized manifest.

* **Refactor**
  * Consolidated dashboard routes and navigation menu configuration into a unified registry source.
  * Updated the app routing system to dynamically reference the centralized configuration instead of hardcoded route definitions.
  * Simplified route verification checks to focus on registry integration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->