### PR TITLE
test: harden route registry coverage checks

### DIFF
--- a/api/tests/test_route_registry_hardening.py
+++ b/api/tests/test_route_registry_hardening.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_route_registry_hardening_enforces_manifest_component_and_icon_coverage() -> None:
+    route_registry_source = (ROOT / 'web' / 'src' / 'routeRegistry.tsx').read_text(encoding='utf-8')
+    route_smoke_source = (ROOT / 'web' / 'scripts' / 'check-routes.mjs').read_text(encoding='utf-8')
+
+    assert 'assertRouteRegistryCoverage' in route_registry_source
+    assert 'missingComponentKeys' in route_registry_source
+    assert 'missingIconKeys' in route_registry_source
+    assert 'missingComponentKeys' in route_smoke_source
+    assert 'missingIconKeys' in route_smoke_source

--- a/web/scripts/check-routes.mjs
+++ b/web/scripts/check-routes.mjs
@@ -7,6 +7,15 @@ const appSource = readFileSync(join(root, 'src', 'App.tsx'), 'utf8')
 const layoutSource = readFileSync(join(root, 'src', 'layouts', 'DashboardLayout.tsx'), 'utf8')
 const registrySource = readFileSync(join(root, 'src', 'routeRegistry.tsx'), 'utf8')
 
+const componentMapMatch = registrySource.match(/const componentByKey:[\s\S]*?=\s*\{([\s\S]*?)\n\}/)
+const iconMapMatch = registrySource.match(/const iconByKey:[\s\S]*?=\s*\{([\s\S]*?)\n\}/)
+const extractKeys = (block) => Array.from(block?.matchAll(/['"]?([\w-]+)['"]?\s*:/g) ?? []).map((match) => match[1])
+const componentKeys = new Set(extractKeys(componentMapMatch?.[1]))
+const iconKeys = new Set(extractKeys(iconMapMatch?.[1]))
+const manifestKeys = manifest.routes.map((route) => route.key)
+const missingComponentKeys = manifestKeys.filter((key) => !componentKeys.has(key))
+const missingIconKeys = manifestKeys.filter((key) => key !== 'overview' && !iconKeys.has(key))
+
 const problems = []
 
 if (!registrySource.includes("from '../route-manifest.json'") && !registrySource.includes('from "../route-manifest.json"')) {
@@ -21,9 +30,19 @@ if (!layoutSource.includes('navigationItems')) {
   problems.push('DashboardLayout.tsx missing navigationItems registry usage')
 }
 
+if (missingComponentKeys.length) {
+  problems.push(`routeRegistry.tsx missing component mappings for: ${missingComponentKeys.join(', ')}`)
+}
+
+if (missingIconKeys.length) {
+  problems.push(`routeRegistry.tsx missing icon mappings for: ${missingIconKeys.join(', ')}`)
+}
+
 const summary = {
   routeCount: manifest.routes.length,
   checkedPaths: manifest.routes.map((route) => route.path),
+  missingComponentKeys,
+  missingIconKeys,
   problems,
 }
 

--- a/web/src/routeRegistry.tsx
+++ b/web/src/routeRegistry.tsx
@@ -95,6 +95,29 @@ const groupLabels: Record<RouteGroup, string> = {
 
 const manifestRoutes = routeManifest.routes as ManifestRoute[]
 
+export const missingComponentKeys = manifestRoutes.filter((route) => !(route.key in componentByKey)).map((route) => route.key)
+export const missingIconKeys = manifestRoutes
+  .filter((route) => route.key !== 'overview' && !(route.key in iconByKey))
+  .map((route) => route.key)
+
+export function assertRouteRegistryCoverage(): void {
+  const problems: string[] = []
+
+  if (missingComponentKeys.length) {
+    problems.push(`missing component mappings for: ${missingComponentKeys.join(', ')}`)
+  }
+
+  if (missingIconKeys.length) {
+    problems.push(`missing icon mappings for: ${missingIconKeys.join(', ')}`)
+  }
+
+  if (problems.length) {
+    throw new Error(`route manifest coverage failed: ${problems.join('; ')}`)
+  }
+}
+
+assertRouteRegistryCoverage()
+
 export const dashboardRoutes: DashboardRoute[] = manifestRoutes.map((route) => ({
   ...route,
   icon: iconByKey[route.key],


### PR DESCRIPTION
## Summary
- harden the dashboard route registry against manifest drift at component/icon mapping boundaries
- fail fast in the frontend when a manifest route is missing a component or icon mapping
- extend route smoke checks so CI reports missing manifest-to-registry coverage

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run smoke:routes
- npm run build:ci

Closes #42