### PR TITLE
test: harden route manifest schema checks

### DIFF
--- a/api/tests/test_route_manifest_schema_hardening.py
+++ b/api/tests/test_route_manifest_schema_hardening.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_route_manifest_schema_hardening_enforces_unique_keys_paths_and_allowed_groups() -> None:
+    route_registry_source = (ROOT / 'web' / 'src' / 'routeRegistry.tsx').read_text(encoding='utf-8')
+    route_smoke_source = (ROOT / 'web' / 'scripts' / 'check-routes.mjs').read_text(encoding='utf-8')
+
+    assert 'duplicateRouteKeys' in route_registry_source
+    assert 'duplicateRoutePaths' in route_registry_source
+    assert 'invalidRouteGroups' in route_registry_source
+    assert 'allowedRouteGroups' in route_registry_source
+
+    assert 'duplicateRouteKeys' in route_smoke_source
+    assert 'duplicateRoutePaths' in route_smoke_source
+    assert 'invalidRouteGroups' in route_smoke_source

--- a/web/scripts/check-routes.mjs
+++ b/web/scripts/check-routes.mjs
@@ -13,6 +13,14 @@ const extractKeys = (block) => Array.from(block?.matchAll(/['"]?([\w-]+)['"]?\s*
 const componentKeys = new Set(extractKeys(componentMapMatch?.[1]))
 const iconKeys = new Set(extractKeys(iconMapMatch?.[1]))
 const manifestKeys = manifest.routes.map((route) => route.key)
+const manifestPaths = manifest.routes.map((route) => route.path)
+const allowedRouteGroups = ['control-group', 'settings-group']
+const countDuplicates = (values) => values.filter((value, index) => values.indexOf(value) !== index).filter((value, index, items) => items.indexOf(value) === index)
+const duplicateRouteKeys = countDuplicates(manifestKeys)
+const duplicateRoutePaths = countDuplicates(manifestPaths)
+const invalidRouteGroups = manifest.routes
+  .map((route) => route.group)
+  .filter((group, index, groups) => !allowedRouteGroups.includes(group) && groups.indexOf(group) === index)
 const missingComponentKeys = manifestKeys.filter((key) => !componentKeys.has(key))
 const missingIconKeys = manifestKeys.filter((key) => key !== 'overview' && !iconKeys.has(key))
 
@@ -30,6 +38,18 @@ if (!layoutSource.includes('navigationItems')) {
   problems.push('DashboardLayout.tsx missing navigationItems registry usage')
 }
 
+if (duplicateRouteKeys.length) {
+  problems.push(`route-manifest.json has duplicate route keys: ${duplicateRouteKeys.join(', ')}`)
+}
+
+if (duplicateRoutePaths.length) {
+  problems.push(`route-manifest.json has duplicate route paths: ${duplicateRoutePaths.join(', ')}`)
+}
+
+if (invalidRouteGroups.length) {
+  problems.push(`route-manifest.json has invalid route groups: ${invalidRouteGroups.join(', ')}`)
+}
+
 if (missingComponentKeys.length) {
   problems.push(`routeRegistry.tsx missing component mappings for: ${missingComponentKeys.join(', ')}`)
 }
@@ -41,6 +61,9 @@ if (missingIconKeys.length) {
 const summary = {
   routeCount: manifest.routes.length,
   checkedPaths: manifest.routes.map((route) => route.path),
+  duplicateRouteKeys,
+  duplicateRoutePaths,
+  invalidRouteGroups,
   missingComponentKeys,
   missingIconKeys,
   problems,

--- a/web/src/routeRegistry.tsx
+++ b/web/src/routeRegistry.tsx
@@ -38,6 +38,8 @@ const WorkspacePage = lazy(() => import('./pages/WorkspacePage').then((module) =
 
 type RouteGroup = 'control-group' | 'settings-group'
 
+const allowedRouteGroups: RouteGroup[] = ['control-group', 'settings-group']
+
 type ManifestRoute = {
   key: string
   path: string
@@ -95,6 +97,15 @@ const groupLabels: Record<RouteGroup, string> = {
 
 const manifestRoutes = routeManifest.routes as ManifestRoute[]
 
+const countDuplicates = (values: string[]): string[] =>
+  values.filter((value, index) => values.indexOf(value) !== index).filter((value, index, items) => items.indexOf(value) === index)
+
+export const duplicateRouteKeys = countDuplicates(manifestRoutes.map((route) => route.key))
+export const duplicateRoutePaths = countDuplicates(manifestRoutes.map((route) => route.path))
+export const invalidRouteGroups = manifestRoutes
+  .map((route) => route.group)
+  .filter((group, index, groups) => !allowedRouteGroups.includes(group) && groups.indexOf(group) === index)
+
 export const missingComponentKeys = manifestRoutes.filter((route) => !(route.key in componentByKey)).map((route) => route.key)
 export const missingIconKeys = manifestRoutes
   .filter((route) => route.key !== 'overview' && !(route.key in iconByKey))
@@ -102,6 +113,18 @@ export const missingIconKeys = manifestRoutes
 
 export function assertRouteRegistryCoverage(): void {
   const problems: string[] = []
+
+  if (duplicateRouteKeys.length) {
+    problems.push(`duplicate route keys: ${duplicateRouteKeys.join(', ')}`)
+  }
+
+  if (duplicateRoutePaths.length) {
+    problems.push(`duplicate route paths: ${duplicateRoutePaths.join(', ')}`)
+  }
+
+  if (invalidRouteGroups.length) {
+    problems.push(`invalid route groups: ${invalidRouteGroups.join(', ')}`)
+  }
 
   if (missingComponentKeys.length) {
     problems.push(`missing component mappings for: ${missingComponentKeys.join(', ')}`)


### PR DESCRIPTION
## Summary
- harden the dashboard route manifest against duplicate keys, duplicate paths, and invalid route groups
- extend route registry fail-fast coverage so invalid manifest structure is rejected before runtime drift spreads
- surface the new schema integrity checks in route smoke output for CI visibility

## Test Plan
- /opt/hermes/.venv/bin/python -m pytest api/tests -q
- npm run lint
- npm run smoke:routes
- npm run build:ci

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for route manifest schema validation.

* **Chores**
  * Enhanced route manifest validation to detect duplicate keys, duplicate paths, and enforce allowed route groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->