### PR TITLE
feat: add config schema contract v1

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -12,6 +12,7 @@ from app.models import (
     AgentConfigPatchRequest,
     AgentConfigReloadResponse,
     AgentConfigResponse,
+    AgentConfigSchemaResponse,
     AgentCronJob,
     AgentCronJobCreateRequest,
     AgentCronJobDeleteResponse,
@@ -633,6 +634,12 @@ def get_agent_logs(
 def get_agent_config(agent_id: str) -> AgentConfigResponse:
     ensure_profile_exists(agent_id)
     return config_service.get_config(agent_id)
+
+
+@app.get('/api/agents/{agent_id}/config/schema', response_model=AgentConfigSchemaResponse, tags=['config'])
+def get_agent_config_schema(agent_id: str) -> AgentConfigSchemaResponse:
+    ensure_profile_exists(agent_id)
+    return config_service.get_schema(agent_id)
 
 
 @app.patch('/api/agents/{agent_id}/config', response_model=AgentConfigResponse, tags=['config'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -370,6 +370,35 @@ class AgentConfigResponse(BaseModel):
     write_restrictions: list[str]
 
 
+class ConfigFieldDescriptor(BaseModel):
+    key: str
+    label: str
+    description: str
+    type: str
+    status: str
+    impact: str
+    value: Any = None
+    sensitive: bool = False
+    options: list[str] = Field(default_factory=list)
+
+
+class ConfigSectionDescriptor(BaseModel):
+    key: str
+    label: str
+    fields: list[ConfigFieldDescriptor]
+
+
+class AgentConfigSchemaResponse(BaseModel):
+    agent_id: str
+    path: str
+    sections: list[ConfigSectionDescriptor]
+    deferred_fields: list[ConfigFieldDescriptor]
+    field_count: int
+    editable_count: int
+    deferred_count: int
+    forbidden_count: int
+
+
 class AgentConfigPatchRequest(BaseModel):
     model: dict[str, Any] | None = None
     display: dict[str, Any] | None = None

--- a/api/app/services/config_service.py
+++ b/api/app/services/config_service.py
@@ -5,7 +5,14 @@ from typing import Any
 
 import yaml
 
-from app.models import AgentConfigReloadResponse, AgentConfigResponse, RuntimeToggles
+from app.models import (
+    AgentConfigReloadResponse,
+    AgentConfigResponse,
+    AgentConfigSchemaResponse,
+    ConfigFieldDescriptor,
+    ConfigSectionDescriptor,
+    RuntimeToggles,
+)
 from app.services.hermes_adapter import ensure_profile_exists
 from app.utils import load_yaml_file, redact_secrets
 
@@ -22,6 +29,87 @@ WRITE_RESTRICTIONS = [
     'Only display.personality, model.default/provider, and runtime toggles are writable in this slice.',
 ]
 
+SCHEMA_SECTIONS = [
+    {
+        'key': 'model',
+        'label': 'Model',
+        'fields': [
+            {
+                'key': 'model.default',
+                'label': 'Default model',
+                'description': 'Primary model used for new runs unless overridden.',
+                'type': 'string',
+                'status': 'editable',
+                'impact': 'new_session',
+            },
+            {
+                'key': 'model.provider',
+                'label': 'Default provider',
+                'description': 'Provider used for new runs unless overridden.',
+                'type': 'string',
+                'status': 'editable',
+                'impact': 'new_session',
+            },
+        ],
+    },
+    {
+        'key': 'display',
+        'label': 'Display',
+        'fields': [
+            {
+                'key': 'display.personality',
+                'label': 'Personality',
+                'description': 'Active personality preset for the profile.',
+                'type': 'string',
+                'status': 'editable',
+                'impact': 'new_session',
+            },
+        ],
+    },
+    {
+        'key': 'runtime',
+        'label': 'Runtime',
+        'fields': [
+            {
+                'key': 'runtime.checkpoints_enabled',
+                'label': 'Checkpoints enabled',
+                'description': 'Enable checkpoint creation during agent execution.',
+                'type': 'boolean',
+                'status': 'editable',
+                'impact': 'reload',
+            },
+            {
+                'key': 'runtime.worktree_enabled',
+                'label': 'Worktree enabled',
+                'description': 'Enable isolated git worktree behavior for execution.',
+                'type': 'boolean',
+                'status': 'editable',
+                'impact': 'reload',
+            },
+        ],
+    },
+]
+
+DEFERRED_SCHEMA_FIELDS = [
+    {
+        'key': 'providers.custom.api_key',
+        'label': 'Provider API key',
+        'description': 'Credential-bearing provider settings stay deferred in config schema v1.',
+        'type': 'string',
+        'status': 'deferred',
+        'impact': 'restart',
+        'sensitive': True,
+    },
+    {
+        'key': 'fallback_providers',
+        'label': 'Fallback providers',
+        'description': 'Fallback chains remain read-only until a later config editor slice.',
+        'type': 'list',
+        'status': 'deferred',
+        'impact': 'new_session',
+    },
+]
+
 
 class ConfigService:
     def get_config(self, agent_id: str) -> AgentConfigResponse:
@@ -29,6 +117,33 @@ class ConfigService:
         config_path = context.home / 'config.yaml'
         config = load_yaml_file(config_path)
         return self._response(agent_id, config_path, config)
+
+    def get_schema(self, agent_id: str) -> AgentConfigSchemaResponse:
+        context = ensure_profile_exists(agent_id)
+        config_path = context.home / 'config.yaml'
+        config = load_yaml_file(config_path)
+
+        sections = [
+            ConfigSectionDescriptor(
+                key=section['key'],
+                label=section['label'],
+                fields=[self._field_descriptor(config, field) for field in section['fields']],
+            )
+            for section in SCHEMA_SECTIONS
+        ]
+        deferred_fields = [self._field_descriptor(config, field) for field in DEFERRED_SCHEMA_FIELDS]
+
+        return AgentConfigSchemaResponse(
+            agent_id=agent_id,
+            path=str(config_path),
+            sections=sections,
+            deferred_fields=deferred_fields,
+            field_count=sum(len(section.fields) for section in sections) + len(deferred_fields),
+            editable_count=sum(1 for section in sections for field in section.fields if field.status == 'editable'),
+            deferred_count=sum(1 for field in deferred_fields if field.status == 'deferred'),
+            forbidden_count=sum(1 for section in sections for field in section.fields if field.status == 'forbidden')
+            + sum(1 for field in deferred_fields if field.status == 'forbidden'),
+        )
 
     def patch_config(self, agent_id: str, payload: dict[str, Any]) -> AgentConfigResponse:
         context = ensure_profile_exists(agent_id)
@@ -81,6 +196,30 @@ class ConfigService:
             deferred_fields=DEFERRED_FIELDS,
             write_restrictions=WRITE_RESTRICTIONS,
         )
+
+    def _field_descriptor(self, config: dict[str, Any], definition: dict[str, Any]) -> ConfigFieldDescriptor:
+        value = self._get_path_value(config, definition['key'])
+        if definition.get('sensitive') and value is not None:
+            value = '***redacted***'
+        return ConfigFieldDescriptor(
+            key=definition['key'],
+            label=definition['label'],
+            description=definition['description'],
+            type=definition['type'],
+            status=definition['status'],
+            impact=definition['impact'],
+            value=value,
+            sensitive=bool(definition.get('sensitive', False)),
+            options=list(definition.get('options', [])),
+        )
+
+    def _get_path_value(self, config: dict[str, Any], dotted_key: str) -> Any:
+        current: Any = config
+        for part in dotted_key.split('.'):
+            if not isinstance(current, dict) or part not in current:
+                return None
+            current = current[part]
+        return current
 
 
 config_service = ConfigService()

--- a/api/tests/test_agent_config_api.py
+++ b/api/tests/test_agent_config_api.py
@@ -105,3 +105,51 @@ def test_agent_config_reload_endpoint_returns_reload_status(tmp_path, monkeypatc
         'reloaded': True,
         'message': 'Config reload requested',
     }
+
+
+def test_agent_config_schema_endpoint_returns_grouped_field_metadata(tmp_path, monkeypatch) -> None:
+    from app.services import config_service as config_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'model': {'default': 'gpt-5.4', 'provider': 'custom'},
+            'display': {'personality': 'creative'},
+            'providers': {'custom': {'api_key': 'super-secret'}},
+            'runtime': {'checkpoints_enabled': True, 'worktree_enabled': False},
+            'fallback_providers': ['backup-a'],
+        },
+    )
+
+    monkeypatch.setattr(config_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.get('/api/agents/default/config/schema')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['field_count'] >= 5
+    assert payload['editable_count'] >= 5
+    assert payload['deferred_count'] >= 2
+    assert payload['forbidden_count'] == 0
+
+    sections = {section['key']: section for section in payload['sections']}
+    assert {'model', 'display', 'runtime'} <= sections.keys()
+
+    model_fields = {field['key']: field for field in sections['model']['fields']}
+    assert model_fields['model.default']['status'] == 'editable'
+    assert model_fields['model.default']['type'] == 'string'
+    assert model_fields['model.default']['value'] == 'gpt-5.4'
+    assert model_fields['model.provider']['impact'] == 'new_session'
+
+    runtime_fields = {field['key']: field for field in sections['runtime']['fields']}
+    assert runtime_fields['runtime.checkpoints_enabled']['type'] == 'boolean'
+    assert runtime_fields['runtime.checkpoints_enabled']['value'] is True
+
+    deferred_fields = {field['key']: field for field in payload['deferred_fields']}
+    assert deferred_fields['providers.custom.api_key']['status'] == 'deferred'
+    assert deferred_fields['providers.custom.api_key']['sensitive'] is True
+    assert deferred_fields['providers.custom.api_key']['value'] == '***redacted***'
+    assert deferred_fields['fallback_providers']['value'] == ['backup-a']


### PR DESCRIPTION
## Summary
- add config schema response models for grouped field metadata
- expose `/api/agents/{agentId}/config/schema` from the dashboard API
- add backend coverage for grouped sections and sensitive-field redaction

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_agent_config_api.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`

Part of #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration schema endpoint now available, providing detailed metadata about agent configuration structure including field types, sections, and sensitivity information for protected fields.

* **Tests**
  * Added tests verifying the configuration schema endpoint functionality and metadata accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->