### PR TITLE
feat: add config validate contract v1

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -13,6 +13,7 @@ from app.models import (
     AgentConfigReloadResponse,
     AgentConfigResponse,
     AgentConfigSchemaResponse,
+    AgentConfigValidationResponse,
     AgentCronJob,
     AgentCronJobCreateRequest,
     AgentCronJobDeleteResponse,
@@ -640,6 +641,12 @@ def get_agent_config(agent_id: str) -> AgentConfigResponse:
 def get_agent_config_schema(agent_id: str) -> AgentConfigSchemaResponse:
     ensure_profile_exists(agent_id)
     return config_service.get_schema(agent_id)
+
+
+@app.post('/api/agents/{agent_id}/config/validate', response_model=AgentConfigValidationResponse, tags=['config'])
+def validate_agent_config(agent_id: str, payload: AgentConfigPatchRequest) -> AgentConfigValidationResponse:
+    ensure_profile_exists(agent_id)
+    return config_service.validate_config(agent_id, payload.model_dump(exclude_none=True))
 
 
 @app.patch('/api/agents/{agent_id}/config', response_model=AgentConfigResponse, tags=['config'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -399,10 +399,23 @@ class AgentConfigSchemaResponse(BaseModel):
     forbidden_count: int
 
 
+class AgentConfigValidationResponse(BaseModel):
+    agent_id: str
+    valid: bool
+    errors: list[str]
+    warnings: list[str]
+    changed_keys: list[str]
+    requires_reload: bool = False
+    requires_restart: bool = False
+    requires_new_session: bool = False
+
+
 class AgentConfigPatchRequest(BaseModel):
     model: dict[str, Any] | None = None
     display: dict[str, Any] | None = None
     runtime: dict[str, Any] | None = None
+    providers: dict[str, Any] | None = None
+    fallback_providers: list[Any] | None = None
 
 
 class AgentConfigReloadResponse(BaseModel):

--- a/api/app/services/config_service.py
+++ b/api/app/services/config_service.py
@@ -9,6 +9,7 @@ from app.models import (
     AgentConfigReloadResponse,
     AgentConfigResponse,
     AgentConfigSchemaResponse,
+    AgentConfigValidationResponse,
     ConfigFieldDescriptor,
     ConfigSectionDescriptor,
     RuntimeToggles,
@@ -145,6 +146,25 @@ class ConfigService:
             + sum(1 for field in deferred_fields if field.status == 'forbidden'),
         )
 
+    def validate_config(self, agent_id: str, payload: dict[str, Any]) -> AgentConfigValidationResponse:
+        ensure_profile_exists(agent_id)
+
+        changed_keys = self._flatten_payload(payload)
+        errors = [f'{key} is not editable in config v1.' for key in changed_keys if key not in EDITABLE_FIELDS]
+        allowed_keys = [key for key in changed_keys if key in EDITABLE_FIELDS]
+        impacts = [self._impact_for_key(key) for key in allowed_keys]
+
+        return AgentConfigValidationResponse(
+            agent_id=agent_id,
+            valid=not errors,
+            errors=errors,
+            warnings=[],
+            changed_keys=allowed_keys if not errors else [],
+            requires_reload=not errors and any(impact == 'reload' for impact in impacts),
+            requires_restart=not errors and any(impact == 'restart' for impact in impacts),
+            requires_new_session=not errors and any(impact == 'new_session' for impact in impacts),
+        )
+
     def patch_config(self, agent_id: str, payload: dict[str, Any]) -> AgentConfigResponse:
         context = ensure_profile_exists(agent_id)
         config_path = context.home / 'config.yaml'
@@ -220,6 +240,26 @@ class ConfigService:
                 return None
             current = current[part]
         return current
+
+    def _flatten_payload(self, payload: dict[str, Any], prefix: str = '') -> list[str]:
+        changed_keys: list[str] = []
+        for key, value in payload.items():
+            dotted = f'{prefix}.{key}' if prefix else key
+            if isinstance(value, dict):
+                changed_keys.extend(self._flatten_payload(value, dotted))
+            else:
+                changed_keys.append(dotted)
+        return changed_keys
+
+    def _impact_for_key(self, key: str) -> str:
+        for section in SCHEMA_SECTIONS:
+            for field in section['fields']:
+                if field['key'] == key:
+                    return field['impact']
+        for field in DEFERRED_SCHEMA_FIELDS:
+            if field['key'] == key:
+                return field['impact']
+        return 'new_session'
 
 
 config_service = ConfigService()

--- a/api/tests/test_agent_config_api.py
+++ b/api/tests/test_agent_config_api.py
@@ -153,3 +153,68 @@ def test_agent_config_schema_endpoint_returns_grouped_field_metadata(tmp_path, m
     assert deferred_fields['providers.custom.api_key']['sensitive'] is True
     assert deferred_fields['providers.custom.api_key']['value'] == '***redacted***'
     assert deferred_fields['fallback_providers']['value'] == ['backup-a']
+
+
+def test_agent_config_validate_endpoint_reports_change_effects(tmp_path, monkeypatch) -> None:
+    from app.services import config_service as config_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'model': {'default': 'gpt-5.4', 'provider': 'custom'},
+            'display': {'personality': 'creative'},
+            'runtime': {'checkpoints_enabled': True, 'worktree_enabled': False},
+        },
+    )
+
+    monkeypatch.setattr(config_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.post(
+        '/api/agents/default/config/validate',
+        json={
+            'display': {'personality': 'focused'},
+            'runtime': {'checkpoints_enabled': False},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        'agent_id': 'default',
+        'valid': True,
+        'errors': [],
+        'warnings': [],
+        'changed_keys': ['display.personality', 'runtime.checkpoints_enabled'],
+        'requires_reload': True,
+        'requires_restart': False,
+        'requires_new_session': True,
+    }
+
+
+def test_agent_config_validate_endpoint_rejects_forbidden_fields(tmp_path, monkeypatch) -> None:
+    from app.services import config_service as config_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(config_path, {'providers': {'custom': {'api_key': 'super-secret'}}})
+
+    monkeypatch.setattr(config_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.post(
+        '/api/agents/default/config/validate',
+        json={
+            'providers': {'custom': {'api_key': 'attempted-overwrite'}},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['valid'] is False
+    assert payload['changed_keys'] == []
+    assert payload['requires_reload'] is False
+    assert payload['requires_restart'] is False
+    assert payload['requires_new_session'] is False
+    assert payload['errors'] == ['providers.custom.api_key is not editable in config v1.']


### PR DESCRIPTION
## Summary
- add `/api/agents/{agentId}/config/validate` for dry-run config patch validation
- report changed keys and operational effects for supported config updates
- reject forbidden config fields cleanly with backend coverage

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_agent_config_api.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`

Part of #47