### PR TITLE
feat: add env catalog and state contract v1

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -20,6 +20,7 @@ from app.models import (
     AgentCronJobPatchRequest,
     AgentCronJobsResponse,
     AgentDefaults,
+    AgentEnvResponse,
     AgentFiles,
     AgentMemoryProvidersResponse,
     AgentMemoryResponse,
@@ -74,6 +75,7 @@ from app.models import (
     StatusResponse,
     SystemAllowlistsResponse,
     SystemDoctorResponse,
+    SystemEnvCatalogResponse,
     SystemGatewayPatchRequest,
     SystemGatewayPlatformsResponse,
     SystemGatewayResponse,
@@ -107,6 +109,7 @@ from app.services.hermes_adapter import (
 from app.services.config_service import config_service
 from app.services.cron_service import cron_service
 from app.services.diagnostics_service import diagnostics_service
+from app.services.env_service import env_service
 from app.services.gateway_service import gateway_service
 from app.services.mcp_service import mcp_service
 from app.services.memory_service import memory_service
@@ -188,6 +191,11 @@ def get_system_plugins() -> SystemPluginsResponse:
 @app.get('/api/system/providers', response_model=ProviderCatalogResponse, tags=['system'])
 def get_system_providers() -> ProviderCatalogResponse:
     return provider_service.list_providers()
+
+
+@app.get('/api/system/env/catalog', response_model=SystemEnvCatalogResponse, tags=['system'])
+def get_system_env_catalog() -> SystemEnvCatalogResponse:
+    return env_service.get_catalog()
 
 
 @app.get('/api/system/models', response_model=ModelCatalogResponse, tags=['system'])
@@ -635,6 +643,12 @@ def get_agent_logs(
 def get_agent_config(agent_id: str) -> AgentConfigResponse:
     ensure_profile_exists(agent_id)
     return config_service.get_config(agent_id)
+
+
+@app.get('/api/agents/{agent_id}/env', response_model=AgentEnvResponse, tags=['config'])
+def get_agent_env(agent_id: str) -> AgentEnvResponse:
+    ensure_profile_exists(agent_id)
+    return env_service.get_agent_env(agent_id)
 
 
 @app.get('/api/agents/{agent_id}/config/schema', response_model=AgentConfigSchemaResponse, tags=['config'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -425,6 +425,34 @@ class AgentConfigReloadResponse(BaseModel):
     message: str
 
 
+class EnvVariableRecord(BaseModel):
+    key: str
+    category: str
+    description: str
+    sensitive: bool
+    docs_url: str | None = None
+    impact: str
+    is_set: bool
+    redacted_preview: str | None = None
+
+
+class EnvCategoryRecord(BaseModel):
+    key: str
+    label: str
+    variables: list[EnvVariableRecord] = Field(default_factory=list)
+
+
+class SystemEnvCatalogResponse(BaseModel):
+    categories: list[EnvCategoryRecord] = Field(default_factory=list)
+    total_count: int
+
+
+class AgentEnvResponse(BaseModel):
+    agent_id: str
+    path: str
+    variables: list[EnvVariableRecord] = Field(default_factory=list)
+
+
 class ProviderCatalogItem(BaseModel):
     name: str
     config: dict[str, Any]

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,9 +1,10 @@
-from . import config_service, cron_service, diagnostics_service, gateway_service, mcp_service, memory_service, plugin_service, provider_service, security_service, session_service, skill_service, tool_service, workspace_service
+from . import config_service, cron_service, diagnostics_service, env_service, gateway_service, mcp_service, memory_service, plugin_service, provider_service, security_service, session_service, skill_service, tool_service, workspace_service
 
 __all__ = [
     "config_service",
     "cron_service",
     "diagnostics_service",
+    "env_service",
     "gateway_service",
     "mcp_service",
     "memory_service",

--- a/api/app/services/env_service.py
+++ b/api/app/services/env_service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.models import AgentEnvResponse, EnvCategoryRecord, EnvVariableRecord, SystemEnvCatalogResponse
+from app.services.hermes_adapter import ensure_profile_exists
+
+ENV_CATALOG = [
+    {
+        'key': 'providers',
+        'label': 'Providers',
+        'variables': [
+            {
+                'key': 'OPENAI_API_KEY',
+                'description': 'API key for OpenAI-compatible provider access.',
+                'sensitive': True,
+                'impact': 'restart',
+                'docs_url': 'https://docs.hermes-agent.dev/reference/environment-variables',
+            },
+            {
+                'key': 'ANTHROPIC_API_KEY',
+                'description': 'API key for Anthropic provider access.',
+                'sensitive': True,
+                'impact': 'restart',
+                'docs_url': 'https://docs.hermes-agent.dev/reference/environment-variables',
+            },
+        ],
+    },
+    {
+        'key': 'tool_apis',
+        'label': 'Tool APIs',
+        'variables': [
+            {
+                'key': 'TAVILY_API_KEY',
+                'description': 'Optional API key for web search integration.',
+                'sensitive': True,
+                'impact': 'restart',
+                'docs_url': 'https://docs.hermes-agent.dev/reference/environment-variables',
+            },
+        ],
+    },
+    {
+        'key': 'gateway_messaging',
+        'label': 'Gateway & Messaging',
+        'variables': [
+            {
+                'key': 'DISCORD_TOKEN',
+                'description': 'Discord bot token for gateway connectivity.',
+                'sensitive': True,
+                'impact': 'restart',
+                'docs_url': 'https://docs.hermes-agent.dev/reference/environment-variables',
+            },
+        ],
+    },
+    {
+        'key': 'runtime',
+        'label': 'Runtime',
+        'variables': [
+            {
+                'key': 'HERMES_TERMINAL_BACKEND',
+                'description': 'Override terminal backend selection for Hermes runtime.',
+                'sensitive': False,
+                'impact': 'restart',
+                'docs_url': 'https://docs.hermes-agent.dev/reference/environment-variables',
+            },
+        ],
+    },
+]
+
+
+class EnvService:
+    def get_catalog(self) -> SystemEnvCatalogResponse:
+        categories = [
+            EnvCategoryRecord(
+                key=category['key'],
+                label=category['label'],
+                variables=[self._record(definition, None, category['key']) for definition in category['variables']],
+            )
+            for category in ENV_CATALOG
+        ]
+        return SystemEnvCatalogResponse(
+            categories=categories,
+            total_count=sum(len(category.variables) for category in categories),
+        )
+
+    def get_agent_env(self, agent_id: str) -> AgentEnvResponse:
+        context = ensure_profile_exists(agent_id)
+        env_path = context.home / '.env'
+        env_values = self._load_env_file(env_path)
+
+        variables = [
+            self._record(definition, env_values.get(definition['key']), category['key'])
+            for category in ENV_CATALOG
+            for definition in category['variables']
+        ]
+        return AgentEnvResponse(agent_id=agent_id, path=str(env_path), variables=variables)
+
+    def _record(self, definition: dict, value: str | None, category_key: str) -> EnvVariableRecord:
+        return EnvVariableRecord(
+            key=definition['key'],
+            category=category_key,
+            description=definition['description'],
+            sensitive=bool(definition['sensitive']),
+            docs_url=definition.get('docs_url'),
+            impact=definition['impact'],
+            is_set=value is not None,
+            redacted_preview=self._redact(value, bool(definition['sensitive'])) if value is not None else None,
+        )
+
+    def _load_env_file(self, path: Path) -> dict[str, str]:
+        if not path.exists():
+            return {}
+        values: dict[str, str] = {}
+        for line in path.read_text(encoding='utf-8').splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#') or '=' not in stripped:
+                continue
+            key, value = stripped.split('=', 1)
+            values[key.strip()] = value.strip()
+        return values
+
+    def _redact(self, value: str, sensitive: bool) -> str:
+        if not sensitive:
+            return value
+        suffix = value[-4:] if len(value) >= 4 else value
+        return f'***{suffix}'
+
+
+env_service = EnvService()

--- a/api/tests/test_agent_config_api.py
+++ b/api/tests/test_agent_config_api.py
@@ -14,6 +14,10 @@ def write_config(path: Path, payload: dict) -> None:
     path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
 
 
+def write_env(path: Path, payload: dict[str, str]) -> None:
+    path.write_text('\n'.join(f'{key}={value}' for key, value in payload.items()) + '\n', encoding='utf-8')
+
+
 def test_agent_config_endpoint_returns_redacted_effective_config(tmp_path, monkeypatch) -> None:
     from app.services import config_service as config_service_module
 
@@ -218,3 +222,48 @@ def test_agent_config_validate_endpoint_rejects_forbidden_fields(tmp_path, monke
     assert payload['requires_restart'] is False
     assert payload['requires_new_session'] is False
     assert payload['errors'] == ['providers.custom.api_key is not editable in config v1.']
+
+
+def test_system_env_catalog_endpoint_returns_grouped_known_keys() -> None:
+    response = client.get('/api/system/env/catalog')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['total_count'] >= 4
+    categories = {category['key']: category for category in payload['categories']}
+    assert {'providers', 'tool_apis', 'gateway_messaging', 'runtime'} <= categories.keys()
+
+    provider_keys = {record['key']: record for record in categories['providers']['variables']}
+    assert provider_keys['OPENAI_API_KEY']['sensitive'] is True
+    assert provider_keys['OPENAI_API_KEY']['impact'] == 'restart'
+    assert provider_keys['OPENAI_API_KEY']['docs_url']
+
+
+def test_agent_env_endpoint_returns_masked_state(tmp_path, monkeypatch) -> None:
+    from app.services import env_service as env_service_module
+
+    env_path = tmp_path / '.env'
+    write_env(
+        env_path,
+        {
+            'OPENAI_API_KEY': 'sk-live-1234567890',
+            'DISCORD_TOKEN': 'discord-secret-abcdef',
+        },
+    )
+
+    monkeypatch.setattr(env_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.get('/api/agents/default/env')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['path'] == str(env_path)
+    records = {record['key']: record for record in payload['variables']}
+    assert records['OPENAI_API_KEY']['is_set'] is True
+    assert records['OPENAI_API_KEY']['redacted_preview'].startswith('***')
+    assert records['DISCORD_TOKEN']['is_set'] is True
+    assert records['DISCORD_TOKEN']['redacted_preview'].startswith('***')
+    assert records['ANTHROPIC_API_KEY']['is_set'] is False
+    assert records['ANTHROPIC_API_KEY']['redacted_preview'] is None


### PR DESCRIPTION
## Summary
- add system env catalog and agent env state contracts
- expose `/api/system/env/catalog` and `/api/agents/{agentId}/env`
- add backend coverage for env catalog grouping and secret masking

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_agent_config_api.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`

Part of #47