### PR TITLE
feat: add env single-key CRUD contract v1

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -20,7 +20,9 @@ from app.models import (
     AgentCronJobPatchRequest,
     AgentCronJobsResponse,
     AgentDefaults,
+    AgentEnvMutationResponse,
     AgentEnvResponse,
+    AgentEnvUpdateRequest,
     AgentFiles,
     AgentMemoryProvidersResponse,
     AgentMemoryResponse,
@@ -649,6 +651,18 @@ def get_agent_config(agent_id: str) -> AgentConfigResponse:
 def get_agent_env(agent_id: str) -> AgentEnvResponse:
     ensure_profile_exists(agent_id)
     return env_service.get_agent_env(agent_id)
+
+
+@app.put('/api/agents/{agent_id}/env/{key}', response_model=AgentEnvMutationResponse, tags=['config'])
+def put_agent_env(agent_id: str, key: str, payload: AgentEnvUpdateRequest) -> AgentEnvMutationResponse:
+    ensure_profile_exists(agent_id)
+    return env_service.set_agent_env(agent_id, key, payload.value)
+
+
+@app.delete('/api/agents/{agent_id}/env/{key}', response_model=AgentEnvMutationResponse, tags=['config'])
+def delete_agent_env(agent_id: str, key: str) -> AgentEnvMutationResponse:
+    ensure_profile_exists(agent_id)
+    return env_service.delete_agent_env(agent_id, key)
 
 
 @app.get('/api/agents/{agent_id}/config/schema', response_model=AgentConfigSchemaResponse, tags=['config'])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -453,6 +453,19 @@ class AgentEnvResponse(BaseModel):
     variables: list[EnvVariableRecord] = Field(default_factory=list)
 
 
+class AgentEnvUpdateRequest(BaseModel):
+    value: str
+
+
+class AgentEnvMutationResponse(BaseModel):
+    agent_id: str
+    path: str
+    key: str
+    is_set: bool
+    redacted_preview: str | None = None
+    message: str
+
+
 class ProviderCatalogItem(BaseModel):
     name: str
     config: dict[str, Any]

--- a/api/app/services/env_service.py
+++ b/api/app/services/env_service.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from app.models import AgentEnvResponse, EnvCategoryRecord, EnvVariableRecord, SystemEnvCatalogResponse
+from app.models import (
+    AgentEnvMutationResponse,
+    AgentEnvResponse,
+    AgentEnvUpdateRequest,
+    EnvCategoryRecord,
+    EnvVariableRecord,
+    SystemEnvCatalogResponse,
+)
 from app.services.hermes_adapter import ensure_profile_exists
 
 ENV_CATALOG = [
@@ -95,6 +102,36 @@ class EnvService:
         ]
         return AgentEnvResponse(agent_id=agent_id, path=str(env_path), variables=variables)
 
+    def set_agent_env(self, agent_id: str, key: str, value: str) -> AgentEnvMutationResponse:
+        context = ensure_profile_exists(agent_id)
+        env_path = context.home / '.env'
+        env_values = self._load_env_file(env_path)
+        env_values[key] = value
+        self._write_env_file(env_path, env_values)
+        return AgentEnvMutationResponse(
+            agent_id=agent_id,
+            path=str(env_path),
+            key=key,
+            is_set=True,
+            redacted_preview=self._redact(value, self._is_sensitive(key)),
+            message='Environment variable updated',
+        )
+
+    def delete_agent_env(self, agent_id: str, key: str) -> AgentEnvMutationResponse:
+        context = ensure_profile_exists(agent_id)
+        env_path = context.home / '.env'
+        env_values = self._load_env_file(env_path)
+        env_values.pop(key, None)
+        self._write_env_file(env_path, env_values)
+        return AgentEnvMutationResponse(
+            agent_id=agent_id,
+            path=str(env_path),
+            key=key,
+            is_set=False,
+            redacted_preview=None,
+            message='Environment variable deleted',
+        )
+
     def _record(self, definition: dict, value: str | None, category_key: str) -> EnvVariableRecord:
         return EnvVariableRecord(
             key=definition['key'],
@@ -118,6 +155,18 @@ class EnvService:
             key, value = stripped.split('=', 1)
             values[key.strip()] = value.strip()
         return values
+
+    def _write_env_file(self, path: Path, values: dict[str, str]) -> None:
+        lines = [f'{key}={value}' for key, value in values.items()]
+        content = ('\n'.join(lines) + '\n') if lines else ''
+        path.write_text(content, encoding='utf-8')
+
+    def _is_sensitive(self, key: str) -> bool:
+        for category in ENV_CATALOG:
+            for definition in category['variables']:
+                if definition['key'] == key:
+                    return bool(definition['sensitive'])
+        return True
 
     def _redact(self, value: str, sensitive: bool) -> str:
         if not sensitive:

--- a/api/tests/test_agent_config_api.py
+++ b/api/tests/test_agent_config_api.py
@@ -267,3 +267,54 @@ def test_agent_env_endpoint_returns_masked_state(tmp_path, monkeypatch) -> None:
     assert records['DISCORD_TOKEN']['redacted_preview'].startswith('***')
     assert records['ANTHROPIC_API_KEY']['is_set'] is False
     assert records['ANTHROPIC_API_KEY']['redacted_preview'] is None
+
+
+def test_agent_env_put_endpoint_sets_single_key(tmp_path, monkeypatch) -> None:
+    from app.services import env_service as env_service_module
+
+    env_path = tmp_path / '.env'
+    write_env(env_path, {'OPENAI_API_KEY': 'old-secret'})
+
+    monkeypatch.setattr(env_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.put('/api/agents/default/env/ANTHROPIC_API_KEY', json={'value': 'new-anthropic-secret'})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['key'] == 'ANTHROPIC_API_KEY'
+    assert payload['is_set'] is True
+    assert payload['redacted_preview'].startswith('***')
+    assert payload['message'] == 'Environment variable updated'
+    env_contents = env_path.read_text(encoding='utf-8')
+    assert 'ANTHROPIC_API_KEY=new-anthropic-secret' in env_contents
+
+
+def test_agent_env_delete_endpoint_removes_single_key(tmp_path, monkeypatch) -> None:
+    from app.services import env_service as env_service_module
+
+    env_path = tmp_path / '.env'
+    write_env(
+        env_path,
+        {
+            'OPENAI_API_KEY': 'old-secret',
+            'ANTHROPIC_API_KEY': 'delete-me',
+        },
+    )
+
+    monkeypatch.setattr(env_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.delete('/api/agents/default/env/ANTHROPIC_API_KEY')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['agent_id'] == 'default'
+    assert payload['key'] == 'ANTHROPIC_API_KEY'
+    assert payload['is_set'] is False
+    assert payload['redacted_preview'] is None
+    assert payload['message'] == 'Environment variable deleted'
+    env_contents = env_path.read_text(encoding='utf-8')
+    assert 'ANTHROPIC_API_KEY=delete-me' not in env_contents
+    assert 'OPENAI_API_KEY=old-secret' in env_contents


### PR DESCRIPTION
## Summary
- add env single-key update/delete contracts for dashboard-safe .env management
- expose `PUT /api/agents/{agentId}/env/{key}` and `DELETE /api/agents/{agentId}/env/{key}`
- add backend coverage for single-key persistence and redacted mutation responses

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_agent_config_api.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`

Part of #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoints to update and delete agent environment variables independently.
  * Environment mutations return detailed confirmation including operation status and affected configuration keys.
  * Sensitive values are automatically redacted in responses for enhanced security and privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->