### PR TITLE
feat: add config editor UI skeleton v1

### DIFF
--- a/api/tests/test_config_ui_skeleton.py
+++ b/api/tests/test_config_ui_skeleton.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_config_page_uses_schema_driven_editor_sections() -> None:
+    config_page = (ROOT / 'web' / 'src' / 'pages' / 'ConfigPage.tsx').read_text(encoding='utf-8')
+
+    assert 'getAgentConfigSchema' in config_page
+    assert 'schema?.sections' in config_page
+    assert 'statusColorMap' in config_page
+    assert 'Input' in config_page
+    assert 'Select' in config_page
+    assert 'Editable schema' in config_page
+    assert 'Raw effective config' in config_page
+    assert 'Write restrictions' in config_page

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,6 @@
 import {
   mockAgentConfig,
+  mockAgentConfigSchema,
   mockAgentSecurity,
   mockApprovals,
   mockCheckpoints,
@@ -35,6 +36,7 @@ import {
 } from './mockData'
 import type {
   AgentConfigRecord,
+  AgentConfigSchemaRecord,
   AgentDiagnosticsRecord,
   AgentSecurityRecord,
   ApiResult,
@@ -331,6 +333,41 @@ type BackendAgentConfigResponse = {
   editable_fields: string[]
   deferred_fields: string[]
   write_restrictions: string[]
+}
+
+type BackendAgentConfigSchemaResponse = {
+  agent_id: string
+  path: string
+  sections: Array<{
+    key: string
+    label: string
+    fields: Array<{
+      key: string
+      label: string
+      description: string
+      type: string
+      status: 'editable' | 'deferred' | 'forbidden'
+      impact: string
+      value?: unknown
+      sensitive?: boolean
+      options?: string[]
+    }>
+  }>
+  deferred_fields: Array<{
+    key: string
+    label: string
+    description: string
+    type: string
+    status: 'editable' | 'deferred' | 'forbidden'
+    impact: string
+    value?: unknown
+    sensitive?: boolean
+    options?: string[]
+  }>
+  field_count: number
+  editable_count: number
+  deferred_count: number
+  forbidden_count: number
 }
 
 type BackendProvidersResponse = {
@@ -820,6 +857,33 @@ const normalizeAgentConfig = (payload: BackendAgentConfigResponse): AgentConfigR
   editableFields: payload.editable_fields,
   deferredFields: payload.deferred_fields,
   writeRestrictions: payload.write_restrictions,
+})
+
+const normalizeConfigField = (field: BackendAgentConfigSchemaResponse['sections'][number]['fields'][number]) => ({
+  key: field.key,
+  label: field.label,
+  description: field.description,
+  type: field.type,
+  status: field.status,
+  impact: field.impact,
+  value: field.value,
+  sensitive: Boolean(field.sensitive),
+  options: field.options ?? [],
+})
+
+const normalizeAgentConfigSchema = (payload: BackendAgentConfigSchemaResponse): AgentConfigSchemaRecord => ({
+  agentId: payload.agent_id,
+  path: payload.path,
+  sections: payload.sections.map((section) => ({
+    key: section.key,
+    label: section.label,
+    fields: section.fields.map(normalizeConfigField),
+  })),
+  deferredFields: payload.deferred_fields.map(normalizeConfigField),
+  fieldCount: payload.field_count,
+  editableCount: payload.editable_count,
+  deferredCount: payload.deferred_count,
+  forbiddenCount: payload.forbidden_count,
 })
 
 const normalizeProviders = (payload: BackendProvidersResponse): ProviderCatalogRecord[] =>
@@ -1312,6 +1376,16 @@ export const apiClient = {
       return normalizeAgentConfig(payload)
     }, () => ({
       ...structuredClone(mockAgentConfig),
+      agentId: profileId,
+      path: `/opt/data/hermes/profiles/${profileId}/config.yaml`,
+    })),
+
+  getAgentConfigSchema: async (profileId: string): Promise<ApiResult<AgentConfigSchemaRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendAgentConfigSchemaResponse>(`/agents/${encodeURIComponent(profileId)}/config/schema`)
+      return normalizeAgentConfigSchema(payload)
+    }, () => ({
+      ...structuredClone(mockAgentConfigSchema),
       agentId: profileId,
       path: `/opt/data/hermes/profiles/${profileId}/config.yaml`,
     })),

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -1,5 +1,6 @@
 import type {
   AgentConfigRecord,
+  AgentConfigSchemaRecord,
   AgentDiagnosticsRecord,
   AgentSecurityRecord,
   ApprovalRecord,
@@ -309,6 +310,114 @@ export const mockAgentConfig: AgentConfigRecord = {
     'Provider credentials and fallback chains remain read-only in Config v1.',
     'Only personality, model selection, and runtime toggles are writable in this slice.',
   ],
+}
+
+export const mockAgentConfigSchema: AgentConfigSchemaRecord = {
+  agentId: 'default',
+  path: '/opt/data/hermes/profiles/default/config.yaml',
+  sections: [
+    {
+      key: 'model',
+      label: 'Model',
+      fields: [
+        {
+          key: 'model.default',
+          label: 'Default model',
+          description: 'Primary model used for new runs unless overridden.',
+          type: 'string',
+          status: 'editable',
+          impact: 'new_session',
+          value: 'gpt-5.4',
+          sensitive: false,
+          options: [],
+        },
+        {
+          key: 'model.provider',
+          label: 'Default provider',
+          description: 'Provider used for new runs unless overridden.',
+          type: 'string',
+          status: 'editable',
+          impact: 'new_session',
+          value: 'custom',
+          sensitive: false,
+          options: [],
+        },
+      ],
+    },
+    {
+      key: 'display',
+      label: 'Display',
+      fields: [
+        {
+          key: 'display.personality',
+          label: 'Personality',
+          description: 'Active personality preset for the profile.',
+          type: 'string',
+          status: 'editable',
+          impact: 'new_session',
+          value: 'creative',
+          sensitive: false,
+          options: [],
+        },
+      ],
+    },
+    {
+      key: 'runtime',
+      label: 'Runtime',
+      fields: [
+        {
+          key: 'runtime.checkpoints_enabled',
+          label: 'Checkpoints enabled',
+          description: 'Enable checkpoint creation during agent execution.',
+          type: 'boolean',
+          status: 'editable',
+          impact: 'reload',
+          value: true,
+          sensitive: false,
+          options: [],
+        },
+        {
+          key: 'runtime.worktree_enabled',
+          label: 'Worktree enabled',
+          description: 'Enable isolated git worktree behavior for execution.',
+          type: 'boolean',
+          status: 'editable',
+          impact: 'reload',
+          value: false,
+          sensitive: false,
+          options: [],
+        },
+      ],
+    },
+  ],
+  deferredFields: [
+    {
+      key: 'providers.custom.api_key',
+      label: 'Provider API key',
+      description: 'Credential-bearing provider settings stay deferred in config schema v1.',
+      type: 'string',
+      status: 'deferred',
+      impact: 'restart',
+      value: '***redacted***',
+      sensitive: true,
+      options: [],
+    },
+    {
+      key: 'fallback_providers',
+      label: 'Fallback providers',
+      description: 'Fallback chains remain read-only until a later config editor slice.',
+      type: 'list',
+      status: 'deferred',
+      impact: 'new_session',
+      value: ['glm-5.1', 'glm-5'],
+      sensitive: false,
+      options: [],
+    },
+  ],
+  fieldCount: 7,
+  editableCount: 5,
+  deferredCount: 2,
+  forbiddenCount: 0,
 }
 
 export const mockProviders: ProviderCatalogRecord[] = [

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -1,88 +1,165 @@
-import { Card, Col, List, Row, Space, Switch, Tag, Typography } from 'antd'
+import { Card, Col, Input, List, Row, Select, Space, Switch, Tag, Typography } from 'antd'
+import { useMemo } from 'react'
 import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
 import { PageHeader } from '../components/PageHeader'
 import { useProfileStore } from '../store/profileStore'
-import type { AgentConfigRecord } from '../types'
+import type { AgentConfigFieldRecord, AgentConfigRecord, AgentConfigSchemaRecord } from '../types'
+
+const statusColorMap: Record<AgentConfigFieldRecord['status'], string> = {
+  editable: 'blue',
+  deferred: 'gold',
+  forbidden: 'red',
+}
+
+const renderFieldControl = (field: AgentConfigFieldRecord) => {
+  const disabled = field.status !== 'editable'
+
+  if (field.type === 'boolean') {
+    return <Switch checked={Boolean(field.value)} disabled />
+  }
+
+  if (field.options.length > 0) {
+    return <Select value={String(field.value ?? '')} options={field.options.map((option) => ({ value: option, label: option }))} disabled={disabled} style={{ width: '100%' }} />
+  }
+
+  return <Input value={field.value == null ? '' : String(field.value)} disabled={disabled} />
+}
 
 export function ConfigPage() {
   const { selectedProfileId } = useProfileStore()
   const profileId = selectedProfileId ?? 'default'
-  const { data, isLoading, isMock, error, refresh } = useApiQuery<AgentConfigRecord>(() => apiClient.getAgentConfig(profileId), [profileId])
+  const {
+    data,
+    isLoading,
+    isMock,
+    error,
+    refresh,
+  } = useApiQuery<AgentConfigRecord>(() => apiClient.getAgentConfig(profileId), [profileId])
+  const {
+    data: schema,
+    isLoading: schemaLoading,
+    isMock: schemaMock,
+    error: schemaError,
+    refresh: refreshSchema,
+  } = useApiQuery<AgentConfigSchemaRecord>(() => apiClient.getAgentConfigSchema(profileId), [profileId, 'schema'])
+
+  const effectiveMock = isMock || schemaMock
+  const effectiveError = error ?? schemaError
+
+  const summaryStats = useMemo(
+    () => [
+      { label: 'Editable', value: schema?.editableCount ?? data?.editableFields.length ?? 0 },
+      { label: 'Deferred', value: schema?.deferredCount ?? data?.deferredFields.length ?? 0 },
+      { label: 'Forbidden', value: schema?.forbiddenCount ?? 0 },
+    ],
+    [data?.deferredFields.length, data?.editableFields.length, schema?.deferredCount, schema?.editableCount, schema?.forbiddenCount],
+  )
 
   return (
     <div className="page-stack">
       <PageHeader
         title="Config"
-        description="Inspect effective config, profile overrides, runtime toggles, and write restrictions for the active Hermes profile."
-        mock={isMock}
-        error={error}
-        onRefresh={refresh}
+        description="Schema-driven config editor skeleton for the active Hermes profile, with grouped sections, field badges, and raw debug surfaces."
+        mock={effectiveMock}
+        error={effectiveError}
+        onRefresh={() => {
+          refresh()
+          refreshSchema()
+        }}
       />
 
       <Row gutter={[16, 16]}>
         <Col xs={24} md={8}>
-          <Card className="glass-panel qwen-summary-card" loading={isLoading}>
+          <Card className="glass-panel qwen-summary-card" loading={isLoading || schemaLoading}>
             <span className="qwen-summary-label">Profile</span>
-            <Typography.Title level={3}>{data?.agentId ?? profileId}</Typography.Title>
-            <Typography.Text type="secondary">{data?.path ?? 'Config path unavailable'}</Typography.Text>
+            <Typography.Title level={3}>{schema?.agentId ?? data?.agentId ?? profileId}</Typography.Title>
+            <Typography.Text type="secondary">{schema?.path ?? data?.path ?? 'Config path unavailable'}</Typography.Text>
           </Card>
         </Col>
-        <Col xs={24} md={8}>
-          <Card className="glass-panel qwen-summary-card" loading={isLoading}>
-            <span className="qwen-summary-label">Checkpoints</span>
-            <Typography.Title level={3}>{data?.runtimeToggles.checkpointsEnabled ? 'On' : 'Off'}</Typography.Title>
-            <Switch checked={data?.runtimeToggles.checkpointsEnabled} disabled />
+        {summaryStats.map((item) => (
+          <Col xs={24} md={8} key={item.label}>
+            <Card className="glass-panel qwen-summary-card" loading={schemaLoading}>
+              <span className="qwen-summary-label">{item.label}</span>
+              <Typography.Title level={3}>{item.value}</Typography.Title>
+            </Card>
+          </Col>
+        ))}
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={16}>
+          <Card className="glass-panel qwen-section-card" title="Editable schema" loading={schemaLoading}>
+            <Space direction="vertical" size={16} style={{ width: '100%' }}>
+              {(schema?.sections ?? []).map((section) => (
+                <Card key={section.key} type="inner" title={section.label}>
+                  <Space direction="vertical" size={12} style={{ width: '100%' }}>
+                    {section.fields.map((field) => (
+                      <div key={field.key}>
+                        <Space align="start" style={{ width: '100%', justifyContent: 'space-between' }} wrap>
+                          <div>
+                            <Typography.Text strong>{field.label}</Typography.Text>
+                            <div>
+                              <Typography.Text type="secondary">{field.key}</Typography.Text>
+                            </div>
+                          </div>
+                          <Space wrap>
+                            <Tag color={statusColorMap[field.status]}>{field.status}</Tag>
+                            <Tag>{field.impact}</Tag>
+                            <Tag>{field.type}</Tag>
+                          </Space>
+                        </Space>
+                        <Typography.Paragraph type="secondary" style={{ marginTop: 8, marginBottom: 12 }}>
+                          {field.description}
+                        </Typography.Paragraph>
+                        {renderFieldControl(field)}
+                      </div>
+                    ))}
+                  </Space>
+                </Card>
+              ))}
+            </Space>
           </Card>
         </Col>
-        <Col xs={24} md={8}>
-          <Card className="glass-panel qwen-summary-card" loading={isLoading}>
-            <span className="qwen-summary-label">Worktree</span>
-            <Typography.Title level={3}>{data?.runtimeToggles.worktreeEnabled ? 'On' : 'Off'}</Typography.Title>
-            <Switch checked={data?.runtimeToggles.worktreeEnabled} disabled />
-          </Card>
+
+        <Col xs={24} xl={8}>
+          <Space direction="vertical" size={16} style={{ width: '100%' }}>
+            <Card className="glass-panel qwen-section-card" title="Deferred schema" loading={schemaLoading}>
+              <List
+                size="small"
+                dataSource={schema?.deferredFields ?? []}
+                renderItem={(field) => (
+                  <List.Item>
+                    <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                      <Space wrap>
+                        <Typography.Text strong>{field.label}</Typography.Text>
+                        <Tag color={statusColorMap[field.status]}>{field.status}</Tag>
+                        <Tag>{field.impact}</Tag>
+                      </Space>
+                      <Typography.Text type="secondary">{field.key}</Typography.Text>
+                      <Typography.Text type="secondary">{field.description}</Typography.Text>
+                    </Space>
+                  </List.Item>
+                )}
+              />
+            </Card>
+
+            <Card className="glass-panel qwen-section-card" title="Write restrictions" loading={isLoading}>
+              <List size="small" dataSource={data?.writeRestrictions ?? []} renderItem={(item) => <List.Item>{item}</List.Item>} />
+            </Card>
+          </Space>
         </Col>
       </Row>
 
       <Row gutter={[16, 16]}>
         <Col xs={24} xl={12}>
-          <Card className="glass-panel qwen-section-card" title="Effective config" loading={isLoading}>
+          <Card className="glass-panel qwen-section-card" title="Raw effective config" loading={isLoading}>
             <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{JSON.stringify(data?.effectiveConfig ?? {}, null, 2)}</pre>
           </Card>
         </Col>
         <Col xs={24} xl={12}>
-          <Card className="glass-panel qwen-section-card" title="Profile overrides" loading={isLoading}>
+          <Card className="glass-panel qwen-section-card" title="Raw profile overrides" loading={isLoading}>
             <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{JSON.stringify(data?.profileOverrides ?? {}, null, 2)}</pre>
-          </Card>
-        </Col>
-      </Row>
-
-      <Row gutter={[16, 16]}>
-        <Col xs={24} xl={8}>
-          <Card className="glass-panel qwen-section-card" title="Editable fields" loading={isLoading}>
-            <Space wrap>
-              {(data?.editableFields ?? []).map((field) => (
-                <Tag key={field} color="blue">{field}</Tag>
-              ))}
-            </Space>
-          </Card>
-        </Col>
-        <Col xs={24} xl={8}>
-          <Card className="glass-panel qwen-section-card" title="Deferred fields" loading={isLoading}>
-            <Space wrap>
-              {(data?.deferredFields ?? []).map((field) => (
-                <Tag key={field} color="gold">{field}</Tag>
-              ))}
-            </Space>
-          </Card>
-        </Col>
-        <Col xs={24} xl={8}>
-          <Card className="glass-panel qwen-section-card" title="Write restrictions" loading={isLoading}>
-            <List
-              size="small"
-              dataSource={data?.writeRestrictions ?? []}
-              renderItem={(item) => <List.Item>{item}</List.Item>}
-            />
           </Card>
         </Col>
       </Row>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -137,6 +137,35 @@ export interface CronJob {
   deliverTarget?: string
 }
 
+export interface AgentConfigFieldRecord {
+  key: string
+  label: string
+  description: string
+  type: string
+  status: 'editable' | 'deferred' | 'forbidden'
+  impact: string
+  value?: unknown
+  sensitive: boolean
+  options: string[]
+}
+
+export interface AgentConfigSectionRecord {
+  key: string
+  label: string
+  fields: AgentConfigFieldRecord[]
+}
+
+export interface AgentConfigSchemaRecord {
+  agentId: string
+  path: string
+  sections: AgentConfigSectionRecord[]
+  deferredFields: AgentConfigFieldRecord[]
+  fieldCount: number
+  editableCount: number
+  deferredCount: number
+  forbiddenCount: number
+}
+
 export interface AgentConfigRecord {
   agentId: string
   path: string


### PR DESCRIPTION
## Summary
- add schema-driven config editor skeleton with grouped sections and field badges
- wire frontend config page to `/api/agents/{agentId}/config/schema`
- keep raw effective config and write restrictions as secondary debug surfaces

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_config_ui_skeleton.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build:ci`
- [x] `cd web && npm run smoke:routes`

Part of #47