### PR TITLE
feat: add config save preview and reload UX

### DIFF
--- a/api/tests/test_config_ui_skeleton.py
+++ b/api/tests/test_config_ui_skeleton.py
@@ -14,3 +14,22 @@ def test_config_page_uses_schema_driven_editor_sections() -> None:
     assert 'Editable schema' in config_page
     assert 'Raw effective config' in config_page
     assert 'Write restrictions' in config_page
+
+
+def test_config_page_includes_validate_preview_and_reload_save_flow() -> None:
+    config_page = (ROOT / 'web' / 'src' / 'pages' / 'ConfigPage.tsx').read_text(encoding='utf-8')
+    client_source = (ROOT / 'web' / 'src' / 'api' / 'client.ts').read_text(encoding='utf-8')
+
+    assert 'validateAgentConfig' in client_source
+    assert 'patchAgentConfig' in client_source
+    assert 'reloadAgentConfig' in client_source
+
+    assert 'draftValues' in config_page
+    assert 'pendingChanges' in config_page
+    assert 'Validation preview' in config_page
+    assert 'Save changes' in config_page
+    assert 'Discard changes' in config_page
+    assert 'Reload config' in config_page
+    assert 'validateAgentConfig' in config_page
+    assert 'patchAgentConfig' in config_page
+    assert 'reloadAgentConfig' in config_page

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,8 @@
 import {
   mockAgentConfig,
   mockAgentConfigSchema,
+  mockConfigReload,
+  mockConfigValidation,
   mockAgentSecurity,
   mockApprovals,
   mockCheckpoints,
@@ -36,7 +38,9 @@ import {
 } from './mockData'
 import type {
   AgentConfigRecord,
+  AgentConfigReloadRecord,
   AgentConfigSchemaRecord,
+  AgentConfigValidationRecord,
   AgentDiagnosticsRecord,
   AgentSecurityRecord,
   ApiResult,
@@ -368,6 +372,24 @@ type BackendAgentConfigSchemaResponse = {
   editable_count: number
   deferred_count: number
   forbidden_count: number
+}
+
+type BackendAgentConfigValidationResponse = {
+  agent_id: string
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+  changed_keys: string[]
+  requires_reload: boolean
+  requires_restart: boolean
+  requires_new_session: boolean
+}
+
+type BackendAgentConfigReloadResponse = {
+  agent_id: string
+  path: string
+  reloaded: boolean
+  message: string
 }
 
 type BackendProvidersResponse = {
@@ -886,6 +908,24 @@ const normalizeAgentConfigSchema = (payload: BackendAgentConfigSchemaResponse): 
   forbiddenCount: payload.forbidden_count,
 })
 
+const normalizeConfigValidation = (payload: BackendAgentConfigValidationResponse): AgentConfigValidationRecord => ({
+  agentId: payload.agent_id,
+  valid: payload.valid,
+  errors: payload.errors,
+  warnings: payload.warnings,
+  changedKeys: payload.changed_keys,
+  requiresReload: payload.requires_reload,
+  requiresRestart: payload.requires_restart,
+  requiresNewSession: payload.requires_new_session,
+})
+
+const normalizeConfigReload = (payload: BackendAgentConfigReloadResponse): AgentConfigReloadRecord => ({
+  agentId: payload.agent_id,
+  path: payload.path,
+  reloaded: payload.reloaded,
+  message: payload.message,
+})
+
 const normalizeProviders = (payload: BackendProvidersResponse): ProviderCatalogRecord[] =>
   payload.providers.map((provider) => ({
     name: provider.name,
@@ -1386,6 +1426,44 @@ export const apiClient = {
       return normalizeAgentConfigSchema(payload)
     }, () => ({
       ...structuredClone(mockAgentConfigSchema),
+      agentId: profileId,
+      path: `/opt/data/hermes/profiles/${profileId}/config.yaml`,
+    })),
+
+  validateAgentConfig: async (profileId: string, payload: Record<string, unknown>): Promise<ApiResult<AgentConfigValidationRecord>> =>
+    withFallback(async () => {
+      const result = await fetchJson<BackendAgentConfigValidationResponse>(`/agents/${encodeURIComponent(profileId)}/config/validate`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      })
+      return normalizeConfigValidation(result)
+    }, () => ({
+      ...structuredClone(mockConfigValidation),
+      agentId: profileId,
+      changedKeys: Object.keys(payload).length > 0 ? structuredClone(mockConfigValidation.changedKeys) : [],
+    })),
+
+  patchAgentConfig: async (profileId: string, payload: Record<string, unknown>): Promise<ApiResult<AgentConfigRecord>> =>
+    withFallback(async () => {
+      const result = await fetchJson<BackendAgentConfigResponse>(`/agents/${encodeURIComponent(profileId)}/config`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      })
+      return normalizeAgentConfig(result)
+    }, () => ({
+      ...structuredClone(mockAgentConfig),
+      agentId: profileId,
+      path: `/opt/data/hermes/profiles/${profileId}/config.yaml`,
+    })),
+
+  reloadAgentConfig: async (profileId: string): Promise<ApiResult<AgentConfigReloadRecord>> =>
+    withFallback(async () => {
+      const result = await fetchJson<BackendAgentConfigReloadResponse>(`/agents/${encodeURIComponent(profileId)}/config/reload`, {
+        method: 'POST',
+      })
+      return normalizeConfigReload(result)
+    }, () => ({
+      ...structuredClone(mockConfigReload),
       agentId: profileId,
       path: `/opt/data/hermes/profiles/${profileId}/config.yaml`,
     })),

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -1,6 +1,8 @@
 import type {
   AgentConfigRecord,
+  AgentConfigReloadRecord,
   AgentConfigSchemaRecord,
+  AgentConfigValidationRecord,
   AgentDiagnosticsRecord,
   AgentSecurityRecord,
   ApprovalRecord,
@@ -329,7 +331,7 @@ export const mockAgentConfigSchema: AgentConfigSchemaRecord = {
           impact: 'new_session',
           value: 'gpt-5.4',
           sensitive: false,
-          options: [],
+          options: ['gpt-5.4', 'gpt-5-mini', 'glm-5.1'],
         },
         {
           key: 'model.provider',
@@ -340,7 +342,7 @@ export const mockAgentConfigSchema: AgentConfigSchemaRecord = {
           impact: 'new_session',
           value: 'custom',
           sensitive: false,
-          options: [],
+          options: ['custom', 'backup'],
         },
       ],
     },
@@ -357,7 +359,7 @@ export const mockAgentConfigSchema: AgentConfigSchemaRecord = {
           impact: 'new_session',
           value: 'creative',
           sensitive: false,
-          options: [],
+          options: ['creative', 'focused', 'supportive'],
         },
       ],
     },
@@ -418,6 +420,24 @@ export const mockAgentConfigSchema: AgentConfigSchemaRecord = {
   editableCount: 5,
   deferredCount: 2,
   forbiddenCount: 0,
+}
+
+export const mockConfigValidation: AgentConfigValidationRecord = {
+  agentId: 'default',
+  valid: true,
+  errors: [],
+  warnings: [],
+  changedKeys: ['display.personality'],
+  requiresReload: false,
+  requiresRestart: false,
+  requiresNewSession: true,
+}
+
+export const mockConfigReload: AgentConfigReloadRecord = {
+  agentId: 'default',
+  path: '/opt/data/hermes/profiles/default/config.yaml',
+  reloaded: true,
+  message: 'Config reload requested',
 }
 
 export const mockProviders: ProviderCatalogRecord[] = [

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -1,10 +1,15 @@
-import { Card, Col, Input, List, Row, Select, Space, Switch, Tag, Typography } from 'antd'
-import { useMemo } from 'react'
+import { Alert, Button, Card, Col, Input, List, Row, Select, Space, Switch, Tag, Typography } from 'antd'
+import { useState } from 'react'
 import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
 import { PageHeader } from '../components/PageHeader'
 import { useProfileStore } from '../store/profileStore'
-import type { AgentConfigFieldRecord, AgentConfigRecord, AgentConfigSchemaRecord } from '../types'
+import type {
+  AgentConfigFieldRecord,
+  AgentConfigRecord,
+  AgentConfigSchemaRecord,
+  AgentConfigValidationRecord,
+} from '../types'
 
 const statusColorMap: Record<AgentConfigFieldRecord['status'], string> = {
   editable: 'blue',
@@ -12,18 +17,28 @@ const statusColorMap: Record<AgentConfigFieldRecord['status'], string> = {
   forbidden: 'red',
 }
 
-const renderFieldControl = (field: AgentConfigFieldRecord) => {
-  const disabled = field.status !== 'editable'
+const setNestedValue = (target: Record<string, unknown>, dottedKey: string, value: unknown) => {
+  const parts = dottedKey.split('.')
+  let cursor: Record<string, unknown> = target
 
-  if (field.type === 'boolean') {
-    return <Switch checked={Boolean(field.value)} disabled />
-  }
+  parts.forEach((part, index) => {
+    if (index === parts.length - 1) {
+      cursor[part] = value
+      return
+    }
 
-  if (field.options.length > 0) {
-    return <Select value={String(field.value ?? '')} options={field.options.map((option) => ({ value: option, label: option }))} disabled={disabled} style={{ width: '100%' }} />
-  }
+    if (typeof cursor[part] !== 'object' || cursor[part] === null || Array.isArray(cursor[part])) {
+      cursor[part] = {}
+    }
 
-  return <Input value={field.value == null ? '' : String(field.value)} disabled={disabled} />
+    cursor = cursor[part] as Record<string, unknown>
+  })
+}
+
+const buildPatchPayload = (draftValues: Record<string, unknown>) => {
+  const payload: Record<string, unknown> = {}
+  Object.entries(draftValues).forEach(([key, value]) => setNestedValue(payload, key, value))
+  return payload
 }
 
 export function ConfigPage() {
@@ -44,23 +59,100 @@ export function ConfigPage() {
     refresh: refreshSchema,
   } = useApiQuery<AgentConfigSchemaRecord>(() => apiClient.getAgentConfigSchema(profileId), [profileId, 'schema'])
 
+  const [draftValues, setDraftValues] = useState<Record<string, unknown>>({})
+  const [validationPreview, setValidationPreview] = useState<AgentConfigValidationRecord | null>(null)
+  const [actionMessage, setActionMessage] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
   const effectiveMock = isMock || schemaMock
   const effectiveError = error ?? schemaError
 
-  const summaryStats = useMemo(
-    () => [
-      { label: 'Editable', value: schema?.editableCount ?? data?.editableFields.length ?? 0 },
-      { label: 'Deferred', value: schema?.deferredCount ?? data?.deferredFields.length ?? 0 },
-      { label: 'Forbidden', value: schema?.forbiddenCount ?? 0 },
-    ],
-    [data?.deferredFields.length, data?.editableFields.length, schema?.deferredCount, schema?.editableCount, schema?.forbiddenCount],
-  )
+  const pendingChanges = Object.entries(draftValues).map(([key, value]) => ({
+    key,
+    value,
+  }))
+
+  const summaryStats = [
+    { label: 'Editable', value: schema?.editableCount ?? data?.editableFields.length ?? 0 },
+    { label: 'Deferred', value: schema?.deferredCount ?? data?.deferredFields.length ?? 0 },
+    { label: 'Forbidden', value: schema?.forbiddenCount ?? 0 },
+  ]
+
+  const setFieldValue = (fieldKey: string, value: unknown) => {
+    setDraftValues((current) => ({ ...current, [fieldKey]: value }))
+  }
+
+  const getFieldValue = (field: AgentConfigFieldRecord) => (field.key in draftValues ? draftValues[field.key] : field.value)
+
+  const runValidationPreview = async () => {
+    const payload = buildPatchPayload(draftValues)
+    const result = await apiClient.validateAgentConfig(profileId, payload)
+    setValidationPreview(result.data)
+    setActionMessage(result.mock ? 'Validation preview shown from fallback data.' : 'Validation preview updated.')
+  }
+
+  const saveChanges = async () => {
+    const payload = buildPatchPayload(draftValues)
+    setIsSubmitting(true)
+    try {
+      const validation = await apiClient.validateAgentConfig(profileId, payload)
+      setValidationPreview(validation.data)
+
+      if (!validation.data.valid) {
+        setActionMessage('Validation blocked save. Fix the flagged config keys first.')
+        return
+      }
+
+      await apiClient.patchAgentConfig(profileId, payload)
+      setDraftValues({})
+      setActionMessage('Config changes saved.')
+      refresh()
+      refreshSchema()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const reloadConfig = async () => {
+    setIsSubmitting(true)
+    try {
+      const result = await apiClient.reloadAgentConfig(profileId)
+      setActionMessage(result.data.message)
+      refresh()
+      refreshSchema()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const renderFieldControl = (field: AgentConfigFieldRecord) => {
+    const disabled = field.status !== 'editable'
+    const currentValue = getFieldValue(field)
+
+    if (field.type === 'boolean') {
+      return <Switch checked={Boolean(currentValue)} disabled={disabled || isSubmitting} onChange={(checked) => setFieldValue(field.key, checked)} />
+    }
+
+    if (field.options.length > 0) {
+      return (
+        <Select
+          value={String(currentValue ?? '')}
+          options={field.options.map((option) => ({ value: option, label: option }))}
+          disabled={disabled || isSubmitting}
+          onChange={(value) => setFieldValue(field.key, value)}
+          style={{ width: '100%' }}
+        />
+      )
+    }
+
+    return <Input value={currentValue == null ? '' : String(currentValue)} disabled={disabled || isSubmitting} onChange={(event) => setFieldValue(field.key, event.target.value)} />
+  }
 
   return (
     <div className="page-stack">
       <PageHeader
         title="Config"
-        description="Schema-driven config editor skeleton for the active Hermes profile, with grouped sections, field badges, and raw debug surfaces."
+        description="Schema-driven config editor with validation preview, dirty-state tracking, save flow, and reload controls for the active Hermes profile."
         mock={effectiveMock}
         error={effectiveError}
         onRefresh={() => {
@@ -68,6 +160,8 @@ export function ConfigPage() {
           refreshSchema()
         }}
       />
+
+      {actionMessage ? <Alert type="info" showIcon message={actionMessage} /> : null}
 
       <Row gutter={[16, 16]}>
         <Col xs={24} md={8}>
@@ -86,6 +180,51 @@ export function ConfigPage() {
           </Col>
         ))}
       </Row>
+
+      <Card
+        className="glass-panel qwen-section-card"
+        title="Validation preview"
+        extra={
+          <Space wrap>
+            <Button onClick={() => { setDraftValues({}); setValidationPreview(null); setActionMessage('Discarded pending config changes.') }} disabled={pendingChanges.length === 0 || isSubmitting}>
+              Discard changes
+            </Button>
+            <Button onClick={runValidationPreview} disabled={pendingChanges.length === 0 || isSubmitting}>
+              Validate preview
+            </Button>
+            <Button type="primary" onClick={saveChanges} disabled={pendingChanges.length === 0 || isSubmitting} loading={isSubmitting}>
+              Save changes
+            </Button>
+            <Button onClick={reloadConfig} disabled={isSubmitting}>
+              Reload config
+            </Button>
+          </Space>
+        }
+      >
+        <Space direction="vertical" size={12} style={{ width: '100%' }}>
+          <Typography.Text type="secondary">
+            Pending changes: {pendingChanges.length}
+          </Typography.Text>
+          <List
+            size="small"
+            dataSource={pendingChanges}
+            locale={{ emptyText: 'No unsaved config changes.' }}
+            renderItem={(item) => <List.Item>{item.key}: {String(item.value)}</List.Item>}
+          />
+          {validationPreview ? (
+            <Space direction="vertical" size={8} style={{ width: '100%' }}>
+              <Space wrap>
+                <Tag color={validationPreview.valid ? 'green' : 'red'}>{validationPreview.valid ? 'valid' : 'invalid'}</Tag>
+                {validationPreview.requiresReload ? <Tag color="blue">reload</Tag> : null}
+                {validationPreview.requiresRestart ? <Tag color="orange">restart</Tag> : null}
+                {validationPreview.requiresNewSession ? <Tag color="purple">new session</Tag> : null}
+              </Space>
+              {validationPreview.errors.length > 0 ? <Alert type="error" showIcon message={validationPreview.errors.join(' | ')} /> : null}
+              {validationPreview.warnings.length > 0 ? <Alert type="warning" showIcon message={validationPreview.warnings.join(' | ')} /> : null}
+            </Space>
+          ) : null}
+        </Space>
+      </Card>
 
       <Row gutter={[16, 16]}>
         <Col xs={24} xl={16}>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -166,6 +166,24 @@ export interface AgentConfigSchemaRecord {
   forbiddenCount: number
 }
 
+export interface AgentConfigValidationRecord {
+  agentId: string
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+  changedKeys: string[]
+  requiresReload: boolean
+  requiresRestart: boolean
+  requiresNewSession: boolean
+}
+
+export interface AgentConfigReloadRecord {
+  agentId: string
+  path: string
+  reloaded: boolean
+  message: string
+}
+
 export interface AgentConfigRecord {
   agentId: string
   path: string


### PR DESCRIPTION
## Summary
- add config dirty-state tracking, validation preview, save flow, and reload actions
- wire frontend config page to validate/patch/reload contracts
- keep preview and write restrictions visible alongside the schema-driven editor

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_config_ui_skeleton.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build:ci`
- [x] `cd web && npm run smoke:routes`

Part of #47