### PR TITLE
feat: add env and api keys page v1

### DIFF
--- a/api/tests/test_config_ui_skeleton.py
+++ b/api/tests/test_config_ui_skeleton.py
@@ -33,3 +33,19 @@ def test_config_page_includes_validate_preview_and_reload_save_flow() -> None:
     assert 'validateAgentConfig' in config_page
     assert 'patchAgentConfig' in config_page
     assert 'reloadAgentConfig' in config_page
+
+
+def test_config_page_includes_env_and_api_keys_workspace() -> None:
+    config_page = (ROOT / 'web' / 'src' / 'pages' / 'ConfigPage.tsx').read_text(encoding='utf-8')
+    client_source = (ROOT / 'web' / 'src' / 'api' / 'client.ts').read_text(encoding='utf-8')
+
+    assert 'getSystemEnvCatalog' in client_source
+    assert 'getAgentEnv' in client_source
+    assert 'setAgentEnv' in client_source
+    assert 'deleteAgentEnv' in client_source
+
+    assert 'Env & API Keys' in config_page
+    assert 'systemEnvCatalog' in config_page
+    assert 'agentEnvState' in config_page
+    assert 'Save key' in config_page
+    assert 'Delete key' in config_page

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,6 +3,9 @@ import {
   mockAgentConfigSchema,
   mockConfigReload,
   mockConfigValidation,
+  mockAgentEnv,
+  mockAgentEnvMutation,
+  mockSystemEnvCatalog,
   mockAgentSecurity,
   mockApprovals,
   mockCheckpoints,
@@ -41,6 +44,8 @@ import type {
   AgentConfigReloadRecord,
   AgentConfigSchemaRecord,
   AgentConfigValidationRecord,
+  AgentEnvMutationRecord,
+  AgentEnvRecord,
   AgentDiagnosticsRecord,
   AgentSecurityRecord,
   ApiResult,
@@ -71,6 +76,7 @@ import type {
   SkillBroadcastPayload,
   SystemAllowlistsRecord,
   SystemDoctorRecord,
+  SystemEnvCatalogRecord,
   SystemGatewayRecord,
   SystemHealthRecord,
   SystemMemoryProfileRecord,
@@ -389,6 +395,41 @@ type BackendAgentConfigReloadResponse = {
   agent_id: string
   path: string
   reloaded: boolean
+  message: string
+}
+
+type BackendEnvVariable = {
+  key: string
+  category: string
+  description: string
+  sensitive: boolean
+  docs_url?: string | null
+  impact: string
+  is_set: boolean
+  redacted_preview?: string | null
+}
+
+type BackendSystemEnvCatalogResponse = {
+  categories: Array<{
+    key: string
+    label: string
+    variables: BackendEnvVariable[]
+  }>
+  total_count: number
+}
+
+type BackendAgentEnvResponse = {
+  agent_id: string
+  path: string
+  variables: BackendEnvVariable[]
+}
+
+type BackendAgentEnvMutationResponse = {
+  agent_id: string
+  path: string
+  key: string
+  is_set: boolean
+  redacted_preview?: string | null
   message: string
 }
 
@@ -923,6 +964,41 @@ const normalizeConfigReload = (payload: BackendAgentConfigReloadResponse): Agent
   agentId: payload.agent_id,
   path: payload.path,
   reloaded: payload.reloaded,
+  message: payload.message,
+})
+
+const normalizeEnvVariable = (payload: BackendEnvVariable): import('../types').EnvVariableRecord => ({
+  key: payload.key,
+  category: payload.category,
+  description: payload.description,
+  sensitive: payload.sensitive,
+  docsUrl: payload.docs_url ?? undefined,
+  impact: payload.impact,
+  isSet: payload.is_set,
+  redactedPreview: payload.redacted_preview ?? null,
+})
+
+const normalizeSystemEnvCatalog = (payload: BackendSystemEnvCatalogResponse): SystemEnvCatalogRecord => ({
+  categories: payload.categories.map((category) => ({
+    key: category.key,
+    label: category.label,
+    variables: category.variables.map(normalizeEnvVariable),
+  })),
+  totalCount: payload.total_count,
+})
+
+const normalizeAgentEnv = (payload: BackendAgentEnvResponse): AgentEnvRecord => ({
+  agentId: payload.agent_id,
+  path: payload.path,
+  variables: payload.variables.map(normalizeEnvVariable),
+})
+
+const normalizeAgentEnvMutation = (payload: BackendAgentEnvMutationResponse): AgentEnvMutationRecord => ({
+  agentId: payload.agent_id,
+  path: payload.path,
+  key: payload.key,
+  isSet: payload.is_set,
+  redactedPreview: payload.redacted_preview ?? null,
   message: payload.message,
 })
 
@@ -1467,6 +1543,35 @@ export const apiClient = {
       agentId: profileId,
       path: `/opt/data/hermes/profiles/${profileId}/config.yaml`,
     })),
+
+  getSystemEnvCatalog: async (): Promise<ApiResult<SystemEnvCatalogRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendSystemEnvCatalogResponse>('/system/env/catalog')
+      return normalizeSystemEnvCatalog(payload)
+    }, () => structuredClone(mockSystemEnvCatalog)),
+
+  getAgentEnv: async (profileId: string): Promise<ApiResult<AgentEnvRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendAgentEnvResponse>(`/agents/${encodeURIComponent(profileId)}/env`)
+      return normalizeAgentEnv(payload)
+    }, () => ({ ...structuredClone(mockAgentEnv), agentId: profileId, path: `/opt/data/hermes/profiles/${profileId}/.env` })),
+
+  setAgentEnv: async (profileId: string, key: string, value: string): Promise<ApiResult<AgentEnvMutationRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendAgentEnvMutationResponse>(`/agents/${encodeURIComponent(profileId)}/env/${encodeURIComponent(key)}`, {
+        method: 'PUT',
+        body: JSON.stringify({ value }),
+      })
+      return normalizeAgentEnvMutation(payload)
+    }, () => ({ ...structuredClone(mockAgentEnvMutation), agentId: profileId, key, isSet: true })),
+
+  deleteAgentEnv: async (profileId: string, key: string): Promise<ApiResult<AgentEnvMutationRecord>> =>
+    withFallback(async () => {
+      const payload = await fetchJson<BackendAgentEnvMutationResponse>(`/agents/${encodeURIComponent(profileId)}/env/${encodeURIComponent(key)}`, {
+        method: 'DELETE',
+      })
+      return normalizeAgentEnvMutation(payload)
+    }, () => ({ ...structuredClone(mockAgentEnvMutation), agentId: profileId, key, isSet: false, redactedPreview: undefined, message: 'Environment variable deleted' })),
 
   getProviders: async (): Promise<ApiResult<ProviderCatalogRecord[]>> =>
     withFallback(async () => {

--- a/web/src/api/mockData.ts
+++ b/web/src/api/mockData.ts
@@ -3,6 +3,8 @@ import type {
   AgentConfigReloadRecord,
   AgentConfigSchemaRecord,
   AgentConfigValidationRecord,
+  AgentEnvMutationRecord,
+  AgentEnvRecord,
   AgentDiagnosticsRecord,
   AgentSecurityRecord,
   ApprovalRecord,
@@ -24,6 +26,7 @@ import type {
   SessionRecord,
   Skill,
   SystemAllowlistsRecord,
+  SystemEnvCatalogRecord,
   SystemGatewayRecord,
   SystemHealthRecord,
   SystemDoctorRecord,
@@ -438,6 +441,42 @@ export const mockConfigReload: AgentConfigReloadRecord = {
   path: '/opt/data/hermes/profiles/default/config.yaml',
   reloaded: true,
   message: 'Config reload requested',
+}
+
+export const mockSystemEnvCatalog: SystemEnvCatalogRecord = {
+  totalCount: 5,
+  categories: [
+    {
+      key: 'providers',
+      label: 'Providers',
+      variables: [
+        { key: 'OPENAI_API_KEY', category: 'providers', description: 'API key for OpenAI-compatible provider access.', sensitive: true, docsUrl: 'https://docs.hermes-agent.dev/reference/environment-variables', impact: 'restart', isSet: true, redactedPreview: '***7890' },
+        { key: 'ANTHROPIC_API_KEY', category: 'providers', description: 'API key for Anthropic provider access.', sensitive: true, docsUrl: 'https://docs.hermes-agent.dev/reference/environment-variables', impact: 'restart', isSet: false, redactedPreview: null },
+      ],
+    },
+    {
+      key: 'gateway_messaging',
+      label: 'Gateway & Messaging',
+      variables: [
+        { key: 'DISCORD_TOKEN', category: 'gateway_messaging', description: 'Discord bot token for gateway connectivity.', sensitive: true, docsUrl: 'https://docs.hermes-agent.dev/reference/environment-variables', impact: 'restart', isSet: true, redactedPreview: '***cdef' },
+      ],
+    },
+  ],
+}
+
+export const mockAgentEnv: AgentEnvRecord = {
+  agentId: 'default',
+  path: '/opt/data/hermes/profiles/default/.env',
+  variables: mockSystemEnvCatalog.categories.flatMap((category) => category.variables),
+}
+
+export const mockAgentEnvMutation: AgentEnvMutationRecord = {
+  agentId: 'default',
+  path: '/opt/data/hermes/profiles/default/.env',
+  key: 'ANTHROPIC_API_KEY',
+  isSet: true,
+  redactedPreview: '***cret',
+  message: 'Environment variable updated',
 }
 
 export const mockProviders: ProviderCatalogRecord[] = [

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Card, Col, Input, List, Row, Select, Space, Switch, Tag, Typography } from 'antd'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
 import { PageHeader } from '../components/PageHeader'
@@ -9,6 +9,8 @@ import type {
   AgentConfigRecord,
   AgentConfigSchemaRecord,
   AgentConfigValidationRecord,
+  AgentEnvRecord,
+  SystemEnvCatalogRecord,
 } from '../types'
 
 const statusColorMap: Record<AgentConfigFieldRecord['status'], string> = {
@@ -58,25 +60,43 @@ export function ConfigPage() {
     error: schemaError,
     refresh: refreshSchema,
   } = useApiQuery<AgentConfigSchemaRecord>(() => apiClient.getAgentConfigSchema(profileId), [profileId, 'schema'])
+  const {
+    data: systemEnvCatalog,
+    isLoading: envCatalogLoading,
+    refresh: refreshEnvCatalog,
+  } = useApiQuery<SystemEnvCatalogRecord>(() => apiClient.getSystemEnvCatalog(), ['system-env-catalog'])
+  const {
+    data: agentEnvState,
+    isLoading: agentEnvLoading,
+    refresh: refreshAgentEnv,
+  } = useApiQuery<AgentEnvRecord>(() => apiClient.getAgentEnv(profileId), [profileId, 'agent-env'])
 
   const [draftValues, setDraftValues] = useState<Record<string, unknown>>({})
   const [validationPreview, setValidationPreview] = useState<AgentConfigValidationRecord | null>(null)
   const [actionMessage, setActionMessage] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [envDraftValues, setEnvDraftValues] = useState<Record<string, string>>({})
 
   const effectiveMock = isMock || schemaMock
   const effectiveError = error ?? schemaError
 
-  const pendingChanges = Object.entries(draftValues).map(([key, value]) => ({
-    key,
-    value,
-  }))
+  const pendingChanges = Object.entries(draftValues).map(([key, value]) => ({ key, value }))
 
   const summaryStats = [
     { label: 'Editable', value: schema?.editableCount ?? data?.editableFields.length ?? 0 },
     { label: 'Deferred', value: schema?.deferredCount ?? data?.deferredFields.length ?? 0 },
     { label: 'Forbidden', value: schema?.forbiddenCount ?? 0 },
   ]
+
+  const envRows = useMemo(() => {
+    const liveRecords = new Map((agentEnvState?.variables ?? []).map((record) => [record.key, record]))
+    return (systemEnvCatalog?.categories ?? []).flatMap((category) =>
+      category.variables.map((variable) => ({
+        ...variable,
+        live: liveRecords.get(variable.key),
+      })),
+    )
+  }, [agentEnvState?.variables, systemEnvCatalog?.categories])
 
   const setFieldValue = (fieldKey: string, value: unknown) => {
     setDraftValues((current) => ({ ...current, [fieldKey]: value }))
@@ -125,6 +145,41 @@ export function ConfigPage() {
     }
   }
 
+  const saveEnvKey = async (key: string) => {
+    const value = envDraftValues[key] ?? ''
+    setIsSubmitting(true)
+    try {
+      const result = await apiClient.setAgentEnv(profileId, key, value)
+      setActionMessage(result.data.message)
+      setEnvDraftValues((current) => {
+        const next = { ...current }
+        delete next[key]
+        return next
+      })
+      refreshEnvCatalog()
+      refreshAgentEnv()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const deleteEnvKey = async (key: string) => {
+    setIsSubmitting(true)
+    try {
+      const result = await apiClient.deleteAgentEnv(profileId, key)
+      setActionMessage(result.data.message)
+      setEnvDraftValues((current) => {
+        const next = { ...current }
+        delete next[key]
+        return next
+      })
+      refreshEnvCatalog()
+      refreshAgentEnv()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   const renderFieldControl = (field: AgentConfigFieldRecord) => {
     const disabled = field.status !== 'editable'
     const currentValue = getFieldValue(field)
@@ -152,12 +207,14 @@ export function ConfigPage() {
     <div className="page-stack">
       <PageHeader
         title="Config"
-        description="Schema-driven config editor with validation preview, dirty-state tracking, save flow, and reload controls for the active Hermes profile."
+        description="Schema-driven config editor with validation preview, save flow, reload controls, and Env & API Keys operations for the active Hermes profile."
         mock={effectiveMock}
         error={effectiveError}
         onRefresh={() => {
           refresh()
           refreshSchema()
+          refreshEnvCatalog()
+          refreshAgentEnv()
         }}
       />
 
@@ -202,15 +259,8 @@ export function ConfigPage() {
         }
       >
         <Space direction="vertical" size={12} style={{ width: '100%' }}>
-          <Typography.Text type="secondary">
-            Pending changes: {pendingChanges.length}
-          </Typography.Text>
-          <List
-            size="small"
-            dataSource={pendingChanges}
-            locale={{ emptyText: 'No unsaved config changes.' }}
-            renderItem={(item) => <List.Item>{item.key}: {String(item.value)}</List.Item>}
-          />
+          <Typography.Text type="secondary">Pending changes: {pendingChanges.length}</Typography.Text>
+          <List size="small" dataSource={pendingChanges} locale={{ emptyText: 'No unsaved config changes.' }} renderItem={(item) => <List.Item>{item.key}: {String(item.value)}</List.Item>} />
           {validationPreview ? (
             <Space direction="vertical" size={8} style={{ width: '100%' }}>
               <Space wrap>
@@ -223,6 +273,25 @@ export function ConfigPage() {
               {validationPreview.warnings.length > 0 ? <Alert type="warning" showIcon message={validationPreview.warnings.join(' | ')} /> : null}
             </Space>
           ) : null}
+        </Space>
+      </Card>
+
+      <Card className="glass-panel qwen-section-card" title="Env & API Keys" loading={envCatalogLoading || agentEnvLoading}>
+        <Space direction="vertical" size={16} style={{ width: '100%' }}>
+          <Typography.Text type="secondary">Manage masked environment-backed credentials and platform tokens for this profile.</Typography.Text>
+          {envRows.map((record) => (
+            <Card key={record.key} type="inner" title={record.key} extra={<Space><Tag>{record.category}</Tag><Tag>{record.impact}</Tag>{record.live?.isSet ? <Tag color="green">set</Tag> : <Tag>unset</Tag>}</Space>}>
+              <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                <Typography.Text type="secondary">{record.description}</Typography.Text>
+                <Typography.Text type="secondary">Preview: {record.live?.redactedPreview ?? 'not set'}</Typography.Text>
+                <Input.Password value={envDraftValues[record.key] ?? ''} onChange={(event) => setEnvDraftValues((current) => ({ ...current, [record.key]: event.target.value }))} placeholder={`Set ${record.key}`} />
+                <Space wrap>
+                  <Button type="primary" onClick={() => saveEnvKey(record.key)} disabled={isSubmitting}>Save key</Button>
+                  <Button danger onClick={() => deleteEnvKey(record.key)} disabled={isSubmitting}>Delete key</Button>
+                </Space>
+              </Space>
+            </Card>
+          ))}
         </Space>
       </Card>
 
@@ -248,9 +317,7 @@ export function ConfigPage() {
                             <Tag>{field.type}</Tag>
                           </Space>
                         </Space>
-                        <Typography.Paragraph type="secondary" style={{ marginTop: 8, marginBottom: 12 }}>
-                          {field.description}
-                        </Typography.Paragraph>
+                        <Typography.Paragraph type="secondary" style={{ marginTop: 8, marginBottom: 12 }}>{field.description}</Typography.Paragraph>
                         {renderFieldControl(field)}
                       </div>
                     ))}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -184,6 +184,43 @@ export interface AgentConfigReloadRecord {
   message: string
 }
 
+export interface EnvVariableRecord {
+  key: string
+  category: string
+  description: string
+  sensitive: boolean
+  docsUrl?: string
+  impact: string
+  isSet: boolean
+  redactedPreview?: string | null
+}
+
+export interface EnvCategoryRecord {
+  key: string
+  label: string
+  variables: EnvVariableRecord[]
+}
+
+export interface SystemEnvCatalogRecord {
+  categories: EnvCategoryRecord[]
+  totalCount: number
+}
+
+export interface AgentEnvRecord {
+  agentId: string
+  path: string
+  variables: EnvVariableRecord[]
+}
+
+export interface AgentEnvMutationRecord {
+  agentId: string
+  path: string
+  key: string
+  isSet: boolean
+  redactedPreview?: string | null
+  message: string
+}
+
 export interface AgentConfigRecord {
   agentId: string
   path: string


### PR DESCRIPTION
## Summary
- add Env & API Keys workspace to the config surface using env catalog and per-agent env state
- wire frontend env read/write/delete actions to the existing dashboard env contracts
- keep config editor and env operations together for the profile-scoped parity slice

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_config_ui_skeleton.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build:ci`
- [x] `cd web && npm run smoke:routes`

Part of #47