### PR TITLE
feat: expand config editable fields v2

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -414,6 +414,11 @@ class AgentConfigPatchRequest(BaseModel):
     model: dict[str, Any] | None = None
     display: dict[str, Any] | None = None
     runtime: dict[str, Any] | None = None
+    browser: dict[str, Any] | None = None
+    terminal: dict[str, Any] | None = None
+    approvals: dict[str, Any] | None = None
+    memory: dict[str, Any] | None = None
+    security: dict[str, Any] | None = None
     providers: dict[str, Any] | None = None
     fallback_providers: list[Any] | None = None
 

--- a/api/app/services/config_service.py
+++ b/api/app/services/config_service.py
@@ -19,15 +19,23 @@ from app.utils import load_yaml_file, redact_secrets
 
 EDITABLE_FIELDS = [
     'display.personality',
+    'display.streaming',
+    'display.show_reasoning',
+    'display.inline_diffs',
     'model.default',
     'model.provider',
     'runtime.checkpoints_enabled',
     'runtime.worktree_enabled',
+    'browser.allow_private_urls',
+    'terminal.timeout',
+    'approvals.mode',
+    'memory.user_profile_enabled',
+    'security.redact_secrets',
 ]
 DEFERRED_FIELDS = ['providers', 'fallback_providers']
 WRITE_RESTRICTIONS = [
-    'Provider credentials and fallback chains remain read-only in Config v1.',
-    'Only display.personality, model.default/provider, and runtime toggles are writable in this slice.',
+    'Provider credentials and fallback chains remain read-only in Config v2.',
+    'Credential-bearing provider settings stay deferred to the Env/API Keys surface.',
 ]
 
 SCHEMA_SECTIONS = [
@@ -65,6 +73,30 @@ SCHEMA_SECTIONS = [
                 'status': 'editable',
                 'impact': 'new_session',
             },
+            {
+                'key': 'display.streaming',
+                'label': 'Streaming output',
+                'description': 'Render streaming response output in the UI when supported.',
+                'type': 'boolean',
+                'status': 'editable',
+                'impact': 'reload',
+            },
+            {
+                'key': 'display.show_reasoning',
+                'label': 'Show reasoning',
+                'description': 'Expose reasoning traces when the runtime/config permits it.',
+                'type': 'boolean',
+                'status': 'editable',
+                'impact': 'reload',
+            },
+            {
+                'key': 'display.inline_diffs',
+                'label': 'Inline diffs',
+                'description': 'Display code and file diffs inline in the dashboard experience.',
+                'type': 'boolean',
+                'status': 'editable',
+                'impact': 'reload',
+            },
         ],
     },
     {
@@ -86,6 +118,77 @@ SCHEMA_SECTIONS = [
                 'type': 'boolean',
                 'status': 'editable',
                 'impact': 'reload',
+            },
+        ],
+    },
+    {
+        'key': 'browser',
+        'label': 'Browser',
+        'fields': [
+            {
+                'key': 'browser.allow_private_urls',
+                'label': 'Allow private URLs',
+                'description': 'Permit browser tooling to access private-network URLs.',
+                'type': 'boolean',
+                'status': 'editable',
+                'impact': 'restart',
+            },
+        ],
+    },
+    {
+        'key': 'terminal',
+        'label': 'Terminal',
+        'fields': [
+            {
+                'key': 'terminal.timeout',
+                'label': 'Terminal timeout',
+                'description': 'Default timeout in seconds for terminal commands.',
+                'type': 'number',
+                'status': 'editable',
+                'impact': 'restart',
+            },
+        ],
+    },
+    {
+        'key': 'approvals',
+        'label': 'Approvals',
+        'fields': [
+            {
+                'key': 'approvals.mode',
+                'label': 'Approval mode',
+                'description': 'Control how dangerous actions are approved.',
+                'type': 'string',
+                'status': 'editable',
+                'impact': 'restart',
+                'options': ['manual', 'auto', 'yolo'],
+            },
+        ],
+    },
+    {
+        'key': 'memory',
+        'label': 'Memory',
+        'fields': [
+            {
+                'key': 'memory.user_profile_enabled',
+                'label': 'User profile memory',
+                'description': 'Persist durable user profile facts across sessions.',
+                'type': 'boolean',
+                'status': 'editable',
+                'impact': 'restart',
+            },
+        ],
+    },
+    {
+        'key': 'security',
+        'label': 'Security',
+        'fields': [
+            {
+                'key': 'security.redact_secrets',
+                'label': 'Redact secrets',
+                'description': 'Mask secrets in UI payloads and logs.',
+                'type': 'boolean',
+                'status': 'editable',
+                'impact': 'restart',
             },
         ],
     },
@@ -172,9 +275,13 @@ class ConfigService:
 
         if isinstance(payload.get('display'), dict):
             config.setdefault('display', {})
-            personality = payload['display'].get('personality')
-            if personality is not None:
-                config['display']['personality'] = personality
+            for key in ['personality', 'streaming', 'show_reasoning', 'inline_diffs']:
+                if key in payload['display']:
+                    value = payload['display'][key]
+                    if key == 'personality':
+                        config['display'][key] = value
+                    else:
+                        config['display'][key] = bool(value)
 
         if isinstance(payload.get('model'), dict):
             config.setdefault('model', {})
@@ -187,6 +294,31 @@ class ConfigService:
             for key in ['checkpoints_enabled', 'worktree_enabled']:
                 if key in payload['runtime']:
                     config['runtime'][key] = bool(payload['runtime'][key])
+
+        if isinstance(payload.get('browser'), dict):
+            config.setdefault('browser', {})
+            if 'allow_private_urls' in payload['browser']:
+                config['browser']['allow_private_urls'] = bool(payload['browser']['allow_private_urls'])
+
+        if isinstance(payload.get('terminal'), dict):
+            config.setdefault('terminal', {})
+            if payload['terminal'].get('timeout') is not None:
+                config['terminal']['timeout'] = int(payload['terminal']['timeout'])
+
+        if isinstance(payload.get('approvals'), dict):
+            config.setdefault('approvals', {})
+            if payload['approvals'].get('mode') is not None:
+                config['approvals']['mode'] = payload['approvals']['mode']
+
+        if isinstance(payload.get('memory'), dict):
+            config.setdefault('memory', {})
+            if 'user_profile_enabled' in payload['memory']:
+                config['memory']['user_profile_enabled'] = bool(payload['memory']['user_profile_enabled'])
+
+        if isinstance(payload.get('security'), dict):
+            config.setdefault('security', {})
+            if 'redact_secrets' in payload['security']:
+                config['security']['redact_secrets'] = bool(payload['security']['redact_secrets'])
 
         config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding='utf-8')
         return self._response(agent_id, config_path, config)

--- a/api/tests/test_agent_config_api.py
+++ b/api/tests/test_agent_config_api.py
@@ -119,7 +119,12 @@ def test_agent_config_schema_endpoint_returns_grouped_field_metadata(tmp_path, m
         config_path,
         {
             'model': {'default': 'gpt-5.4', 'provider': 'custom'},
-            'display': {'personality': 'creative'},
+            'display': {'personality': 'creative', 'streaming': True, 'show_reasoning': True, 'inline_diffs': False},
+            'browser': {'allow_private_urls': False},
+            'terminal': {'timeout': 180},
+            'approvals': {'mode': 'manual'},
+            'memory': {'user_profile_enabled': True},
+            'security': {'redact_secrets': True},
             'providers': {'custom': {'api_key': 'super-secret'}},
             'runtime': {'checkpoints_enabled': True, 'worktree_enabled': False},
             'fallback_providers': ['backup-a'],
@@ -134,13 +139,13 @@ def test_agent_config_schema_endpoint_returns_grouped_field_metadata(tmp_path, m
     assert response.status_code == 200
     payload = response.json()
     assert payload['agent_id'] == 'default'
-    assert payload['field_count'] >= 5
-    assert payload['editable_count'] >= 5
+    assert payload['field_count'] >= 12
+    assert payload['editable_count'] >= 12
     assert payload['deferred_count'] >= 2
     assert payload['forbidden_count'] == 0
 
     sections = {section['key']: section for section in payload['sections']}
-    assert {'model', 'display', 'runtime'} <= sections.keys()
+    assert {'model', 'display', 'runtime', 'browser', 'terminal', 'approvals', 'memory', 'security'} <= sections.keys()
 
     model_fields = {field['key']: field for field in sections['model']['fields']}
     assert model_fields['model.default']['status'] == 'editable'
@@ -151,6 +156,29 @@ def test_agent_config_schema_endpoint_returns_grouped_field_metadata(tmp_path, m
     runtime_fields = {field['key']: field for field in sections['runtime']['fields']}
     assert runtime_fields['runtime.checkpoints_enabled']['type'] == 'boolean'
     assert runtime_fields['runtime.checkpoints_enabled']['value'] is True
+
+    display_fields = {field['key']: field for field in sections['display']['fields']}
+    assert display_fields['display.streaming']['type'] == 'boolean'
+    assert display_fields['display.streaming']['value'] is True
+    assert display_fields['display.show_reasoning']['value'] is True
+    assert display_fields['display.inline_diffs']['value'] is False
+
+    browser_fields = {field['key']: field for field in sections['browser']['fields']}
+    assert browser_fields['browser.allow_private_urls']['type'] == 'boolean'
+    assert browser_fields['browser.allow_private_urls']['impact'] == 'restart'
+
+    terminal_fields = {field['key']: field for field in sections['terminal']['fields']}
+    assert terminal_fields['terminal.timeout']['type'] == 'number'
+    assert terminal_fields['terminal.timeout']['value'] == 180
+
+    approvals_fields = {field['key']: field for field in sections['approvals']['fields']}
+    assert approvals_fields['approvals.mode']['options'] == ['manual', 'auto', 'yolo']
+
+    memory_fields = {field['key']: field for field in sections['memory']['fields']}
+    assert memory_fields['memory.user_profile_enabled']['value'] is True
+
+    security_fields = {field['key']: field for field in sections['security']['fields']}
+    assert security_fields['security.redact_secrets']['value'] is True
 
     deferred_fields = {field['key']: field for field in payload['deferred_fields']}
     assert deferred_fields['providers.custom.api_key']['status'] == 'deferred'
@@ -167,8 +195,13 @@ def test_agent_config_validate_endpoint_reports_change_effects(tmp_path, monkeyp
         config_path,
         {
             'model': {'default': 'gpt-5.4', 'provider': 'custom'},
-            'display': {'personality': 'creative'},
+            'display': {'personality': 'creative', 'streaming': False, 'show_reasoning': False, 'inline_diffs': True},
             'runtime': {'checkpoints_enabled': True, 'worktree_enabled': False},
+            'browser': {'allow_private_urls': False},
+            'terminal': {'timeout': 180},
+            'approvals': {'mode': 'manual'},
+            'memory': {'user_profile_enabled': True},
+            'security': {'redact_secrets': True},
         },
     )
 
@@ -178,8 +211,13 @@ def test_agent_config_validate_endpoint_reports_change_effects(tmp_path, monkeyp
     response = client.post(
         '/api/agents/default/config/validate',
         json={
-            'display': {'personality': 'focused'},
+            'display': {'personality': 'focused', 'streaming': True, 'show_reasoning': True, 'inline_diffs': False},
             'runtime': {'checkpoints_enabled': False},
+            'browser': {'allow_private_urls': True},
+            'terminal': {'timeout': 240},
+            'approvals': {'mode': 'auto'},
+            'memory': {'user_profile_enabled': False},
+            'security': {'redact_secrets': False},
         },
     )
 
@@ -190,9 +228,20 @@ def test_agent_config_validate_endpoint_reports_change_effects(tmp_path, monkeyp
         'valid': True,
         'errors': [],
         'warnings': [],
-        'changed_keys': ['display.personality', 'runtime.checkpoints_enabled'],
+        'changed_keys': [
+            'display.personality',
+            'display.streaming',
+            'display.show_reasoning',
+            'display.inline_diffs',
+            'runtime.checkpoints_enabled',
+            'browser.allow_private_urls',
+            'terminal.timeout',
+            'approvals.mode',
+            'memory.user_profile_enabled',
+            'security.redact_secrets',
+        ],
         'requires_reload': True,
-        'requires_restart': False,
+        'requires_restart': True,
         'requires_new_session': True,
     }
 
@@ -222,6 +271,63 @@ def test_agent_config_validate_endpoint_rejects_forbidden_fields(tmp_path, monke
     assert payload['requires_restart'] is False
     assert payload['requires_new_session'] is False
     assert payload['errors'] == ['providers.custom.api_key is not editable in config v1.']
+
+
+def test_agent_config_patch_expands_v2_editable_fields(tmp_path, monkeypatch) -> None:
+    from app.services import config_service as config_service_module
+
+    config_path = tmp_path / 'config.yaml'
+    write_config(
+        config_path,
+        {
+            'display': {'personality': 'creative', 'streaming': False, 'show_reasoning': False, 'inline_diffs': True},
+            'runtime': {'checkpoints_enabled': True, 'worktree_enabled': False},
+            'browser': {'allow_private_urls': False},
+            'terminal': {'timeout': 180},
+            'approvals': {'mode': 'manual'},
+            'memory': {'user_profile_enabled': True},
+            'security': {'redact_secrets': True},
+            'providers': {'custom': {'api_key': 'super-secret'}},
+        },
+    )
+
+    monkeypatch.setattr(config_service_module, 'ensure_profile_exists', lambda profile: SimpleNamespace(home=tmp_path))
+    monkeypatch.setattr('app.main.ensure_profile_exists', lambda agent_id: object())
+
+    response = client.patch(
+        '/api/agents/default/config',
+        json={
+            'display': {'streaming': True, 'show_reasoning': True, 'inline_diffs': False},
+            'browser': {'allow_private_urls': True},
+            'terminal': {'timeout': 240},
+            'approvals': {'mode': 'auto'},
+            'memory': {'user_profile_enabled': False},
+            'security': {'redact_secrets': False},
+            'providers': {'custom': {'api_key': 'should-not-overwrite'}},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['effective_config']['display']['streaming'] is True
+    assert payload['effective_config']['display']['show_reasoning'] is True
+    assert payload['effective_config']['display']['inline_diffs'] is False
+    assert payload['effective_config']['browser']['allow_private_urls'] is True
+    assert payload['effective_config']['terminal']['timeout'] == 240
+    assert payload['effective_config']['approvals']['mode'] == 'auto'
+    assert payload['effective_config']['memory']['user_profile_enabled'] is False
+    assert payload['effective_config']['security']['redact_secrets'] == '***redacted***'
+
+    stored = yaml.safe_load(config_path.read_text(encoding='utf-8'))
+    assert stored['display']['streaming'] is True
+    assert stored['display']['show_reasoning'] is True
+    assert stored['display']['inline_diffs'] is False
+    assert stored['browser']['allow_private_urls'] is True
+    assert stored['terminal']['timeout'] == 240
+    assert stored['approvals']['mode'] == 'auto'
+    assert stored['memory']['user_profile_enabled'] is False
+    assert stored['security']['redact_secrets'] is False
+    assert stored['providers']['custom']['api_key'] == 'super-secret'
 
 
 def test_system_env_catalog_endpoint_returns_grouped_known_keys() -> None:

--- a/api/tests/test_config_ui_skeleton.py
+++ b/api/tests/test_config_ui_skeleton.py
@@ -49,3 +49,18 @@ def test_config_page_includes_env_and_api_keys_workspace() -> None:
     assert 'agentEnvState' in config_page
     assert 'Save key' in config_page
     assert 'Delete key' in config_page
+
+
+def test_config_page_supports_expanded_v2_field_controls() -> None:
+    config_page = (ROOT / 'web' / 'src' / 'pages' / 'ConfigPage.tsx').read_text(encoding='utf-8')
+
+    assert 'display.streaming' in config_page
+    assert 'display.show_reasoning' in config_page
+    assert 'display.inline_diffs' in config_page
+    assert 'browser.allow_private_urls' in config_page
+    assert 'terminal.timeout' in config_page
+    assert 'approvals.mode' in config_page
+    assert 'memory.user_profile_enabled' in config_page
+    assert 'security.redact_secrets' in config_page
+    assert 'InputNumber' in config_page
+    assert "option, label: option" in config_page

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Card, Col, Input, List, Row, Select, Space, Switch, Tag, Typography } from 'antd'
+import { Alert, Button, Card, Col, Input, InputNumber, List, Row, Select, Space, Switch, Tag, Typography } from 'antd'
 import { useMemo, useState } from 'react'
 import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
@@ -18,6 +18,19 @@ const statusColorMap: Record<AgentConfigFieldRecord['status'], string> = {
   deferred: 'gold',
   forbidden: 'red',
 }
+
+const numericFieldKeys = ['terminal.timeout']
+const booleanFieldKeys = [
+  'display.streaming',
+  'display.show_reasoning',
+  'display.inline_diffs',
+  'runtime.checkpoints_enabled',
+  'runtime.worktree_enabled',
+  'browser.allow_private_urls',
+  'memory.user_profile_enabled',
+  'security.redact_secrets',
+]
+const selectFieldKeys = ['approvals.mode']
 
 const setNestedValue = (target: Record<string, unknown>, dottedKey: string, value: unknown) => {
   const parts = dottedKey.split('.')
@@ -184,11 +197,22 @@ export function ConfigPage() {
     const disabled = field.status !== 'editable'
     const currentValue = getFieldValue(field)
 
-    if (field.type === 'boolean') {
+    if (field.type === 'boolean' || booleanFieldKeys.includes(field.key)) {
       return <Switch checked={Boolean(currentValue)} disabled={disabled || isSubmitting} onChange={(checked) => setFieldValue(field.key, checked)} />
     }
 
-    if (field.options.length > 0) {
+    if (field.type === 'number' || numericFieldKeys.includes(field.key)) {
+      return (
+        <InputNumber
+          value={typeof currentValue === 'number' ? currentValue : Number(currentValue ?? 0)}
+          disabled={disabled || isSubmitting}
+          onChange={(value) => setFieldValue(field.key, Number(value ?? 0))}
+          style={{ width: '100%' }}
+        />
+      )
+    }
+
+    if (field.options.length > 0 || selectFieldKeys.includes(field.key)) {
       return (
         <Select
           value={String(currentValue ?? '')}


### PR DESCRIPTION
## Summary
- expand config schema/editability for display, browser, terminal, approvals, memory, and security fields
- update config patch + validation coverage for the new writable fields while keeping secrets deferred
- add UI control coverage for booleans, numeric timeout input, and approval mode selection

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_agent_config_api.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_config_ui_skeleton.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build:ci`
- [x] `cd web && npm run smoke:routes`

Part of #47