### PR TITLE
feat: add provider auth readiness panel

### DIFF
--- a/api/tests/test_provider_auth_readiness_ui.py
+++ b/api/tests/test_provider_auth_readiness_ui.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_providers_page_includes_provider_auth_readiness_panel() -> None:
+    providers_page = (ROOT / 'web' / 'src' / 'pages' / 'ProvidersPage.tsx').read_text(encoding='utf-8')
+    client_source = (ROOT / 'web' / 'src' / 'api' / 'client.ts').read_text(encoding='utf-8')
+
+    assert 'getProviders' in client_source
+    assert 'getSystemEnvCatalog' in client_source
+    assert 'getAgentEnv' in client_source
+
+    assert 'Provider auth readiness' in providers_page
+    assert 'Auth coverage' in providers_page
+    assert 'Env-backed keys' in providers_page
+    assert 'Credential source' in providers_page
+    assert 'providerReadinessRows' in providers_page
+    assert 'systemEnvCatalog' in providers_page
+    assert 'agentEnvState' in providers_page

--- a/web/src/pages/ProvidersPage.tsx
+++ b/web/src/pages/ProvidersPage.tsx
@@ -1,9 +1,11 @@
 import { Card, Col, List, Row, Space, Table, Tag, Typography } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
+import { useMemo } from 'react'
 import { apiClient } from '../api/client'
 import { useApiQuery } from '../api/hooks'
 import { PageHeader } from '../components/PageHeader'
-import type { ModelCatalogRecord, ProviderCatalogRecord, ProviderRoutingRecord } from '../types'
+import { useProfileStore } from '../store/profileStore'
+import type { AgentEnvRecord, ModelCatalogRecord, ProviderCatalogRecord, ProviderRoutingRecord, SystemEnvCatalogRecord } from '../types'
 
 const providerColumns: ColumnsType<ProviderCatalogRecord> = [
   { title: 'Provider', dataIndex: 'name' },
@@ -17,25 +19,66 @@ const modelColumns: ColumnsType<ModelCatalogRecord> = [
   { title: 'Source', dataIndex: 'source' },
 ]
 
+type ProviderReadinessRow = {
+  name: string
+  hasCredentials: boolean
+  credentialSource: string
+  authCoverage: string
+  envBackedKeys: string[]
+}
+
+const providerKeyHints: Record<string, string[]> = {
+  openai: ['OPENAI_API_KEY'],
+  anthropic: ['ANTHROPIC_API_KEY'],
+  custom: ['OPENAI_API_KEY', 'ANTHROPIC_API_KEY'],
+}
+
 export function ProvidersPage() {
+  const { selectedProfileId } = useProfileStore()
+  const profileId = selectedProfileId ?? 'default'
+
   const providersQuery = useApiQuery<ProviderCatalogRecord[]>(apiClient.getProviders, [])
   const modelsQuery = useApiQuery<ModelCatalogRecord[]>(apiClient.getModels, [])
   const routingQuery = useApiQuery<ProviderRoutingRecord>(apiClient.getProviderRouting, [])
+  const systemEnvCatalog = useApiQuery<SystemEnvCatalogRecord>(() => apiClient.getSystemEnvCatalog(), ['providers-env-catalog'])
+  const agentEnvState = useApiQuery<AgentEnvRecord>(() => apiClient.getAgentEnv(profileId), [profileId, 'providers-agent-env'])
 
-  const isMock = providersQuery.isMock || modelsQuery.isMock || routingQuery.isMock
-  const error = providersQuery.error ?? modelsQuery.error ?? routingQuery.error
+  const isMock = providersQuery.isMock || modelsQuery.isMock || routingQuery.isMock || systemEnvCatalog.isMock || agentEnvState.isMock
+  const error = providersQuery.error ?? modelsQuery.error ?? routingQuery.error ?? systemEnvCatalog.error ?? agentEnvState.error
+
+  const providerReadinessRows = useMemo<ProviderReadinessRow[]>(() => {
+    const envCatalogKeys = new Set((systemEnvCatalog.data?.categories ?? []).flatMap((category) => category.variables.map((variable) => variable.key)))
+    const liveEnvMap = new Map((agentEnvState.data?.variables ?? []).map((variable) => [variable.key, variable]))
+
+    return (providersQuery.data ?? []).map((provider) => {
+      const envBackedKeys = (providerKeyHints[provider.name] ?? []).filter((key) => envCatalogKeys.has(key))
+      const configuredEnvKeys = envBackedKeys.filter((key) => liveEnvMap.get(key)?.isSet)
+      const credentialSource = provider.hasCredentials ? 'config' : configuredEnvKeys.length > 0 ? 'env' : 'missing'
+      const authCoverage = provider.hasCredentials || configuredEnvKeys.length > 0 ? 'ready' : 'missing'
+
+      return {
+        name: provider.name,
+        hasCredentials: provider.hasCredentials,
+        credentialSource,
+        authCoverage,
+        envBackedKeys,
+      }
+    })
+  }, [agentEnvState.data?.variables, providersQuery.data, systemEnvCatalog.data?.categories])
 
   return (
     <div className="page-stack">
       <PageHeader
         title="Providers & Models"
-        description="Inspect provider catalogs, model availability, default routing, and fallback chains with secret redaction."
+        description="Inspect provider catalogs, model availability, default routing, fallback chains, and provider auth readiness with secret redaction."
         mock={isMock}
         error={error}
         onRefresh={async () => {
           await providersQuery.refresh()
           await modelsQuery.refresh()
           await routingQuery.refresh()
+          await systemEnvCatalog.refresh()
+          await agentEnvState.refresh()
         }}
       />
 
@@ -102,6 +145,27 @@ export function ProvidersPage() {
           </Card>
         </Col>
       </Row>
+
+      <Card className="glass-panel qwen-section-card" title="Provider auth readiness" loading={providersQuery.isLoading || systemEnvCatalog.isLoading || agentEnvState.isLoading}>
+        <List
+          dataSource={providerReadinessRows}
+          renderItem={(item) => (
+            <List.Item>
+              <Space direction="vertical" size={6} style={{ width: '100%' }}>
+                <Space wrap>
+                  <Typography.Text strong>{item.name}</Typography.Text>
+                  <Tag color={item.authCoverage === 'ready' ? 'green' : 'red'}>Auth coverage: {item.authCoverage}</Tag>
+                  <Tag>Credential source: {item.credentialSource}</Tag>
+                </Space>
+                <Typography.Text type="secondary">Env-backed keys</Typography.Text>
+                <Space wrap>
+                  {item.envBackedKeys.length > 0 ? item.envBackedKeys.map((key) => <Tag key={key}>{key}</Tag>) : <Tag>none</Tag>}
+                </Space>
+              </Space>
+            </List.Item>
+          )}
+        />
+      </Card>
 
       <Card className="glass-panel qwen-section-card" title="Write restrictions" loading={routingQuery.isLoading}>
         <List


### PR DESCRIPTION
## Summary
- add a provider auth readiness panel to the Providers & Models page
- combine provider catalog plus env catalog/state to show auth coverage and credential source signals
- add UI regression coverage for the readiness panel surface

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_provider_auth_readiness_ui.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build:ci`
- [x] `cd web && npm run smoke:routes`

Part of #47