### PR TITLE
refactor: share route manifest validator

### DIFF
--- a/api/tests/test_shared_route_validator.py
+++ b/api/tests/test_shared_route_validator.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_route_registry_and_smoke_script_use_shared_validator_module() -> None:
+    validator_source = (ROOT / 'web' / 'src' / 'routeManifestValidator.ts').read_text(encoding='utf-8')
+    route_registry_source = (ROOT / 'web' / 'src' / 'routeRegistry.tsx').read_text(encoding='utf-8')
+    route_smoke_source = (ROOT / 'web' / 'scripts' / 'check-routes.mjs').read_text(encoding='utf-8')
+
+    assert 'export const allowedRouteGroups' in validator_source
+    assert 'export const countDuplicates' in validator_source
+    assert 'export const collectRouteManifestProblems' in validator_source
+    assert 'duplicateRouteKeys' in validator_source
+    assert 'missingComponentKeys' in validator_source
+
+    assert "from './routeManifestValidator'" in route_registry_source
+    assert 'collectRouteManifestProblems' in route_registry_source
+
+    assert "routeManifestValidator" in route_smoke_source
+    assert 'collectRouteManifestProblems' in route_smoke_source
+    assert 'duplicateRouteKeys = countDuplicates' not in route_smoke_source
+    assert 'const allowedRouteGroups =' not in route_smoke_source

--- a/web/scripts/check-routes.mjs
+++ b/web/scripts/check-routes.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { collectRouteManifestProblems } from '../src/routeManifestValidator.shared.js'
 
 const root = process.cwd()
 const manifest = JSON.parse(readFileSync(join(root, 'route-manifest.json'), 'utf8'))
@@ -10,21 +11,13 @@ const registrySource = readFileSync(join(root, 'src', 'routeRegistry.tsx'), 'utf
 const componentMapMatch = registrySource.match(/const componentByKey:[\s\S]*?=\s*\{([\s\S]*?)\n\}/)
 const iconMapMatch = registrySource.match(/const iconByKey:[\s\S]*?=\s*\{([\s\S]*?)\n\}/)
 const extractKeys = (block) => Array.from(block?.matchAll(/['"]?([\w-]+)['"]?\s*:/g) ?? []).map((match) => match[1])
-const componentKeys = new Set(extractKeys(componentMapMatch?.[1]))
-const iconKeys = new Set(extractKeys(iconMapMatch?.[1]))
-const manifestKeys = manifest.routes.map((route) => route.key)
-const manifestPaths = manifest.routes.map((route) => route.path)
-const allowedRouteGroups = ['control-group', 'settings-group']
-const countDuplicates = (values) => values.filter((value, index) => values.indexOf(value) !== index).filter((value, index, items) => items.indexOf(value) === index)
-const duplicateRouteKeys = countDuplicates(manifestKeys)
-const duplicateRoutePaths = countDuplicates(manifestPaths)
-const invalidRouteGroups = manifest.routes
-  .map((route) => route.group)
-  .filter((group, index, groups) => !allowedRouteGroups.includes(group) && groups.indexOf(group) === index)
-const missingComponentKeys = manifestKeys.filter((key) => !componentKeys.has(key))
-const missingIconKeys = manifestKeys.filter((key) => key !== 'overview' && !iconKeys.has(key))
-
-const problems = []
+const componentKeys = extractKeys(componentMapMatch?.[1])
+const iconKeys = extractKeys(iconMapMatch?.[1])
+const { duplicateRouteKeys, duplicateRoutePaths, invalidRouteGroups, missingComponentKeys, missingIconKeys, problems } = collectRouteManifestProblems({
+  manifestRoutes: manifest.routes,
+  componentKeys,
+  iconKeys,
+})
 
 if (!registrySource.includes("from '../route-manifest.json'") && !registrySource.includes('from "../route-manifest.json"')) {
   problems.push('routeRegistry.tsx missing route-manifest.json import')

--- a/web/src/routeManifestValidator.shared.d.ts
+++ b/web/src/routeManifestValidator.shared.d.ts
@@ -1,0 +1,14 @@
+export const allowedRouteGroups: string[]
+export function countDuplicates(values: string[]): string[]
+export function collectRouteManifestProblems(input: {
+  manifestRoutes: Array<{ key: string; path: string; group: string }>
+  componentKeys: string[]
+  iconKeys: string[]
+}): {
+  duplicateRouteKeys: string[]
+  duplicateRoutePaths: string[]
+  invalidRouteGroups: string[]
+  missingComponentKeys: string[]
+  missingIconKeys: string[]
+  problems: string[]
+}

--- a/web/src/routeManifestValidator.shared.js
+++ b/web/src/routeManifestValidator.shared.js
@@ -1,0 +1,29 @@
+export const allowedRouteGroups = ['control-group', 'settings-group']
+
+export const countDuplicates = (values) =>
+  values.filter((value, index) => values.indexOf(value) !== index).filter((value, index, items) => items.indexOf(value) === index)
+
+export const collectRouteManifestProblems = ({ manifestRoutes, componentKeys, iconKeys }) => {
+  const duplicateRouteKeys = countDuplicates(manifestRoutes.map((route) => route.key))
+  const duplicateRoutePaths = countDuplicates(manifestRoutes.map((route) => route.path))
+  const invalidRouteGroups = manifestRoutes
+    .map((route) => route.group)
+    .filter((group, index, groups) => !allowedRouteGroups.includes(group) && groups.indexOf(group) === index)
+  const missingComponentKeys = manifestRoutes.filter((route) => !componentKeys.includes(route.key)).map((route) => route.key)
+  const missingIconKeys = manifestRoutes.filter((route) => route.key !== 'overview' && !iconKeys.includes(route.key)).map((route) => route.key)
+
+  return {
+    duplicateRouteKeys,
+    duplicateRoutePaths,
+    invalidRouteGroups,
+    missingComponentKeys,
+    missingIconKeys,
+    problems: [
+      ...(duplicateRouteKeys.length ? [`duplicate route keys: ${duplicateRouteKeys.join(', ')}`] : []),
+      ...(duplicateRoutePaths.length ? [`duplicate route paths: ${duplicateRoutePaths.join(', ')}`] : []),
+      ...(invalidRouteGroups.length ? [`invalid route groups: ${invalidRouteGroups.join(', ')}`] : []),
+      ...(missingComponentKeys.length ? [`missing component mappings for: ${missingComponentKeys.join(', ')}`] : []),
+      ...(missingIconKeys.length ? [`missing icon mappings for: ${missingIconKeys.join(', ')}`] : []),
+    ],
+  }
+}

--- a/web/src/routeManifestValidator.ts
+++ b/web/src/routeManifestValidator.ts
@@ -1,0 +1,13 @@
+import { allowedRouteGroups as sharedAllowedRouteGroups, collectRouteManifestProblems as sharedCollectRouteManifestProblems, countDuplicates as sharedCountDuplicates } from './routeManifestValidator.shared.js'
+
+export const allowedRouteGroups = sharedAllowedRouteGroups
+export const countDuplicates = sharedCountDuplicates
+export const collectRouteManifestProblems = sharedCollectRouteManifestProblems
+
+export const sharedRouteManifestProblemKeys = [
+  'duplicateRouteKeys',
+  'duplicateRoutePaths',
+  'invalidRouteGroups',
+  'missingComponentKeys',
+  'missingIconKeys',
+]

--- a/web/src/routeRegistry.tsx
+++ b/web/src/routeRegistry.tsx
@@ -18,6 +18,7 @@ import type { MenuProps } from 'antd'
 import type { ComponentType, LazyExoticComponent, ReactNode } from 'react'
 import { lazy } from 'react'
 import routeManifest from '../route-manifest.json'
+import { allowedRouteGroups, collectRouteManifestProblems } from './routeManifestValidator'
 
 const ConfigPage = lazy(() => import('./pages/ConfigPage').then((module) => ({ default: module.ConfigPage })))
 const ConsolePage = lazy(() => import('./pages/ConsolePage').then((module) => ({ default: module.ConsolePage })))
@@ -38,14 +39,14 @@ const WorkspacePage = lazy(() => import('./pages/WorkspacePage').then((module) =
 
 type RouteGroup = 'control-group' | 'settings-group'
 
-const allowedRouteGroups: RouteGroup[] = ['control-group', 'settings-group']
-
 type ManifestRoute = {
   key: string
   path: string
   label: string
   group: RouteGroup
 }
+
+export const registryAllowedRouteGroups = allowedRouteGroups
 
 type DashboardRoute = ManifestRoute & {
   icon?: ReactNode
@@ -97,42 +98,16 @@ const groupLabels: Record<RouteGroup, string> = {
 
 const manifestRoutes = routeManifest.routes as ManifestRoute[]
 
-const countDuplicates = (values: string[]): string[] =>
-  values.filter((value, index) => values.indexOf(value) !== index).filter((value, index, items) => items.indexOf(value) === index)
+const { duplicateRouteKeys, duplicateRoutePaths, invalidRouteGroups, missingComponentKeys, missingIconKeys, problems: manifestProblems } = collectRouteManifestProblems({
+  manifestRoutes,
+  componentKeys: Object.keys(componentByKey),
+  iconKeys: Object.keys(iconByKey),
+})
 
-export const duplicateRouteKeys = countDuplicates(manifestRoutes.map((route) => route.key))
-export const duplicateRoutePaths = countDuplicates(manifestRoutes.map((route) => route.path))
-export const invalidRouteGroups = manifestRoutes
-  .map((route) => route.group)
-  .filter((group, index, groups) => !allowedRouteGroups.includes(group) && groups.indexOf(group) === index)
-
-export const missingComponentKeys = manifestRoutes.filter((route) => !(route.key in componentByKey)).map((route) => route.key)
-export const missingIconKeys = manifestRoutes
-  .filter((route) => route.key !== 'overview' && !(route.key in iconByKey))
-  .map((route) => route.key)
+export { duplicateRouteKeys, duplicateRoutePaths, invalidRouteGroups, missingComponentKeys, missingIconKeys }
 
 export function assertRouteRegistryCoverage(): void {
-  const problems: string[] = []
-
-  if (duplicateRouteKeys.length) {
-    problems.push(`duplicate route keys: ${duplicateRouteKeys.join(', ')}`)
-  }
-
-  if (duplicateRoutePaths.length) {
-    problems.push(`duplicate route paths: ${duplicateRoutePaths.join(', ')}`)
-  }
-
-  if (invalidRouteGroups.length) {
-    problems.push(`invalid route groups: ${invalidRouteGroups.join(', ')}`)
-  }
-
-  if (missingComponentKeys.length) {
-    problems.push(`missing component mappings for: ${missingComponentKeys.join(', ')}`)
-  }
-
-  if (missingIconKeys.length) {
-    problems.push(`missing icon mappings for: ${missingIconKeys.join(', ')}`)
-  }
+  const problems: string[] = [...manifestProblems]
 
   if (problems.length) {
     throw new Error(`route manifest coverage failed: ${problems.join('; ')}`)


### PR DESCRIPTION
## Summary
- extract shared route manifest validator logic so runtime and CI use the same duplication/coverage checks
- update routeRegistry and smoke script to consume the shared validator module instead of maintaining parallel logic
- add regression coverage that locks the shared-validator wiring in place

## Test Plan
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests/test_shared_route_validator.py -q`
- [x] `/opt/hermes/.venv/bin/python -m pytest api/tests -q`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build:ci`
- [x] `cd web && npm run smoke:routes`

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added smoke tests to validate route validation consistency across the application stack.

* **Refactor**
  * Centralized route manifest validation logic into a shared module, improving code reusability and ensuring consistent validation behavior across multiple components and scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->